### PR TITLE
카테고리 조회를 페이지네이션으로 변경했습니다!

### DIFF
--- a/src/controllers/category.controller.ts
+++ b/src/controllers/category.controller.ts
@@ -1,27 +1,20 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { CategoryEntity } from 'src/entities/category.entity';
+import { PaginationDto } from 'src/entities/dtos/pagination.dto';
+import { PaginationResponseForm } from 'src/interfaces/pagination-response-form.interface';
 import { CategoryService } from 'src/services/category.service';
+import { createPaginationForm } from 'src/util/functions/create-pagination-form.function';
 
 @Controller('category')
 @ApiTags('Categry API')
 export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}
-  /**
-   * 중복된 카테고리가 생겨서도 안 된다.
-   * 이미 있을 경우에는 생성하지 말아야 한다.
-   * 이러한 기본 값 생성 스크립트는 서버 코드와 무관하게 하나의 스크립트로 작성되어야 한다.
-   *
-   * 어렵다면 일단 넘긴다.
-   */
 
-  /**
-   * 카테고리는 이미 들어 있는 rows 라고 가정한다.
-   * 따라서 새로 추가하는 등 POST API는 없고 오로지 조회 요청만을 테스트한다.
-   */
   @Get()
   @ApiOperation({ summary: '카테고리 조회 API', description: '등록된 카테고리를 확인할 수 있다.' })
-  async getCategoryList(): Promise<CategoryEntity[]> {
-    return await this.categoryService.getCategoryList();
+  async getCategory(@Query() paginationDto: PaginationDto): Promise<PaginationResponseForm<CategoryEntity>> {
+    const response = await this.categoryService.getCategory(paginationDto);
+    return createPaginationForm(response, paginationDto);
   }
 }

--- a/src/entities/category.entity.ts
+++ b/src/entities/category.entity.ts
@@ -10,7 +10,7 @@ export class CategoryEntity extends CommonEntity {
     Object.assign(this, dto);
   }
 
-  @Column({ type: 'varchar', length: 128 })
+  @Column({ type: 'varchar', length: 128, unique: true })
   name!: string;
 
   /**

--- a/src/services/category.service.ts
+++ b/src/services/category.service.ts
@@ -1,12 +1,25 @@
 import { Injectable } from '@nestjs/common';
 import { CategoryEntity } from 'src/entities/category.entity';
+import { PaginationDto } from 'src/entities/dtos/pagination.dto';
+import { PaginationResponseForm } from 'src/interfaces/pagination-response-form.interface';
 import { CategoryRepository } from 'src/repositories/category.repository';
+import { getOffset } from 'src/util/functions/get-offset.function';
 
 @Injectable()
 export class CategoryService {
+  companyRepository: any;
   constructor(private readonly categoryRepository: CategoryRepository) {}
 
-  async getCategoryList(): Promise<CategoryEntity[]> {
-    return this.categoryRepository.find();
+  async getCategory(paginationDto: PaginationDto) {
+    const { skip, take } = getOffset(paginationDto);
+    const [list, count] = await this.categoryRepository.findAndCount({
+      order: {
+        name: 'ASC',
+        id: 'ASC',
+      },
+      skip,
+      take,
+    });
+    return { list, count };
   }
 }

--- a/src/test/unit/category.spec.ts
+++ b/src/test/unit/category.spec.ts
@@ -1,13 +1,15 @@
+import { v4 } from 'uuid';
 import { Test } from '@nestjs/testing';
 import { AppModule } from 'src/app.module';
-import { CustomTypeOrmModule } from 'src/configs/custom-typeorm.module';
 import { CategoryController } from 'src/controllers/category.controller';
+import { CategoryEntity } from 'src/entities/category.entity';
 import { CategoryRepository } from 'src/repositories/category.repository';
 import { CategoryService } from 'src/services/category.service';
 
 describe('CategoryController', () => {
   let Controller: CategoryController;
   let Service: CategoryService;
+  let repository: CategoryRepository;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -16,11 +18,13 @@ describe('CategoryController', () => {
 
     Service = module.get<CategoryService>(CategoryService);
     Controller = module.get<CategoryController>(CategoryController);
+    repository = module.get<CategoryRepository>(CategoryRepository);
   });
 
   it('should be defined.', async () => {
     expect(Controller).toBeDefined();
     expect(Service).toBeDefined();
+    expect(repository).toBeDefined();
   });
 
   describe('서버 실행 시 카테고리 데이터를 추가하는 스크립트', () => {
@@ -39,12 +43,21 @@ describe('CategoryController', () => {
      * 카테고리는 이미 들어 있는 rows 라고 가정한다.
      * 따라서 새로 추가하는 등 POST API는 없고 오로지 조회 요청만을 테스트한다.
      *
-     * 한번에 몇개를 조회할건지...
-     *
      */
     it('카테고리가 조회되어야 한다.', async () => {
-      const categorylist = Controller.getCategoryList();
-      expect((await categorylist).length > 1).toBe(true);
+      /**
+       * 카테고리를 10개 생성한다.
+       * 카테고리 명은 unique 해야한다.
+       */
+
+      const entities = new Array(10).fill(0).map((el) => new CategoryEntity({ name: v4() }));
+      await repository.save(entities);
+
+      /**
+       * 저장한 카테고리를 조회할 수 있는 지 확인한다.
+       */
+      const categorylist = Controller.getCategory({ page: 1, limit: 10 });
+      expect((await categorylist).data.list.length).toBe(10);
     });
   });
 });


### PR DESCRIPTION

CategoryEntity의 `name`칼럼에 unique 옵션을 추가하였고
기존의 모든 카테고리를 조회하던 `getCategoryList`를 페이지네이션으로 일부만 가져오도록 변경하였습니다.

모든 변경사항이 잘 반영된 것을 테스트로 확인했습니다! 