### PR TITLE
모든 엔티티의 조인관계를 수정했습니다!

### DIFF
--- a/src/entities/buyer.entity.ts
+++ b/src/entities/buyer.entity.ts
@@ -28,12 +28,12 @@ export class BuyerEntity extends CommonEntity {
    * relations
    */
 
-  @OneToMany(() => BoardEntity, (b) => b.buyerId)
+  @OneToMany(() => BoardEntity, (b) => b.buyer)
   boards!: BoardEntity[];
 
-  @OneToMany(() => CartEntity, (c) => c.buyerId)
+  @OneToMany(() => CartEntity, (c) => c.buyer)
   carts!: CartEntity[];
 
-  @OneToMany(() => OrderEntity, (o) => o.buyerId)
+  @OneToMany(() => OrderEntity, (o) => o.buyer)
   orders!: OrderEntity[];
 }

--- a/src/entities/cart-required-option.entity.ts
+++ b/src/entities/cart-required-option.entity.ts
@@ -27,6 +27,6 @@ export class CartRequiredOptionEntity extends CommonEntity {
   @JoinColumn({ referencedColumnName: 'id' })
   productRequiredOption!: ProductRequiredOptionEntity;
 
-  @OneToMany(() => CartInputOptionEntity, (cpio) => cpio.cartRequiredId)
+  @OneToMany(() => CartInputOptionEntity, (cpio) => cpio.cartRequiredOption)
   cartInputOptions!: CartInputOptionEntity[];
 }

--- a/src/entities/cart.entity.ts
+++ b/src/entities/cart.entity.ts
@@ -29,12 +29,12 @@ export class CartEntity extends CommonEntity {
   @JoinColumn({ referencedColumnName: 'id' })
   product!: ProductEntity;
 
-  @OneToMany(() => CartRequiredOptionEntity, (cpro) => cpro.cartId)
+  @OneToMany(() => CartRequiredOptionEntity, (cpro) => cpro.cart)
   cartRequiredOptions!: CartRequiredOptionEntity[];
 
-  @OneToMany(() => CartOptionEntity, (cpo) => cpo.cartId)
+  @OneToMany(() => CartOptionEntity, (cpo) => cpo.cart)
   cartOptions!: CartOptionEntity[];
 
-  @OneToMany(() => OrderProductEntity, (op) => op.cartId)
+  @OneToMany(() => OrderProductEntity, (op) => op.cart)
   orderProducts!: OrderProductEntity[];
 }

--- a/src/entities/category.entity.ts
+++ b/src/entities/category.entity.ts
@@ -17,6 +17,6 @@ export class CategoryEntity extends CommonEntity {
    * relations
    */
 
-  @OneToMany(() => ProductEntity, (p) => p.categoryId)
+  @OneToMany(() => ProductEntity, (p) => p.category)
   products!: ProductEntity[];
 }

--- a/src/entities/company.entity.ts
+++ b/src/entities/company.entity.ts
@@ -17,6 +17,6 @@ export class CompanyEntity extends CommonEntity {
    * relations
    */
 
-  @OneToMany(() => ProductEntity, (p) => p.companyId)
+  @OneToMany(() => ProductEntity, (p) => p.company)
   products!: ProductEntity[];
 }

--- a/src/entities/order-product-bundle.entity.ts
+++ b/src/entities/order-product-bundle.entity.ts
@@ -21,13 +21,13 @@ export class OrderProductBundleEntity extends CommonEntity {
    * relations
    */
 
-  @OneToMany(() => OrderProductEntity, (op) => op.orderProductId)
+  @OneToMany(() => OrderProductEntity, (op) => op.orderProductBundle)
   orderProducts!: OrderProductEntity[];
 
-  @OneToMany(() => OrderProductRequiredOptionEntity, (opro) => opro.OrderProductBundleId)
+  @OneToMany(() => OrderProductRequiredOptionEntity, (opro) => opro.orderProductBundle)
   orderProductRequiredOptions!: OrderProductRequiredOptionEntity[];
 
-  @OneToMany(() => OrderProductOptionEntity, (opo) => opo.OrderProductOptionId)
+  @OneToMany(() => OrderProductOptionEntity, (opo) => opo.orderProductBundle)
   orderProductOptions!: OrderProductOptionEntity[];
 
   @ManyToOne(() => OrderEntity, (o) => o.orderProductBundles)

--- a/src/entities/order-product-riquired-option.entity.ts
+++ b/src/entities/order-product-riquired-option.entity.ts
@@ -21,6 +21,6 @@ export class OrderProductRequiredOptionEntity extends CommonEntity {
   @JoinColumn({ referencedColumnName: 'id' })
   orderProductBundle!: OrderProductBundleEntity;
 
-  @OneToMany(() => OrderProductInputOptionEntity, (opio) => opio.orderProductRequiredOptionId)
+  @OneToMany(() => OrderProductInputOptionEntity, (opio) => opio.orderProductRequiredOption)
   orderProductInputOptions!: OrderProductInputOptionEntity[];
 }

--- a/src/entities/order.entity.ts
+++ b/src/entities/order.entity.ts
@@ -16,6 +16,6 @@ export class OrderEntity extends CommonEntity {
   @JoinColumn({ referencedColumnName: 'id' })
   buyer!: BuyerEntity;
 
-  @OneToMany(() => OrderProductBundleEntity, (opb) => opb.orderId)
+  @OneToMany(() => OrderProductBundleEntity, (opb) => opb.user)
   orderProductBundles!: OrderProductBundleEntity[];
 }

--- a/src/entities/product-bundle.entity.ts
+++ b/src/entities/product-bundle.entity.ts
@@ -22,6 +22,6 @@ export class ProductBundleEntity extends CommonEntity {
   @JoinColumn({ referencedColumnName: 'id' })
   seller!: SellerEntity;
 
-  @OneToMany(() => ProductEntity, (p) => p.bundleId)
+  @OneToMany(() => ProductEntity, (p) => p.bundle)
   products!: ProductEntity[];
 }

--- a/src/entities/product-input-option.entity.ts
+++ b/src/entities/product-input-option.entity.ts
@@ -28,6 +28,6 @@ export class ProductInputOptionEntity extends CommonEntity {
   @JoinColumn({ referencedColumnName: 'id' })
   productRequiredOption!: ProductRequiredOptionEntity;
 
-  @OneToMany(() => CartInputOptionEntity, (cpio) => cpio.productInputOptionId)
+  @OneToMany(() => CartInputOptionEntity, (cpio) => cpio.productInputOption)
   cartInputOptions!: CartInputOptionEntity[];
 }

--- a/src/entities/product-option.entity.ts
+++ b/src/entities/product-option.entity.ts
@@ -31,6 +31,6 @@ export class ProductOptionEntity extends CommonEntity {
   @JoinColumn({ referencedColumnName: 'id' })
   product!: ProductEntity;
 
-  @OneToMany(() => CartOptionEntity, (cpo) => cpo.productOptionId)
+  @OneToMany(() => CartOptionEntity, (cpo) => cpo.productOption)
   cartOptions!: CartOptionEntity[];
 }

--- a/src/entities/product-required-option.entity.ts
+++ b/src/entities/product-required-option.entity.ts
@@ -32,9 +32,9 @@ export class ProductRequiredOptionEntity extends CommonEntity {
   @JoinColumn({ name: 'product_id', referencedColumnName: 'id' })
   product!: ProductEntity;
 
-  @OneToMany(() => ProductInputOptionEntity, (pio) => pio.productRequiredOptionId)
+  @OneToMany(() => ProductInputOptionEntity, (pio) => pio.productRequiredOption)
   productInputOptions!: ProductInputOptionEntity[];
 
-  @OneToMany(() => CartRequiredOptionEntity, (cpro) => cpro.productRequiredOptionId)
+  @OneToMany(() => CartRequiredOptionEntity, (cpro) => cpro.productRequiredOption)
   cartRequiredOptions!: CartRequiredOptionEntity[];
 }

--- a/src/entities/product-required-option.entity.ts
+++ b/src/entities/product-required-option.entity.ts
@@ -29,7 +29,7 @@ export class ProductRequiredOptionEntity extends CommonEntity {
    */
 
   @ManyToOne(() => ProductEntity, (p) => p.productRequiredOptions)
-  @JoinColumn({ name: 'product_id', referencedColumnName: 'id' })
+  @JoinColumn({ referencedColumnName: 'id' })
   product!: ProductEntity;
 
   @OneToMany(() => ProductInputOptionEntity, (pio) => pio.productRequiredOption)

--- a/src/entities/product.entity.ts
+++ b/src/entities/product.entity.ts
@@ -70,7 +70,7 @@ export class ProductEntity extends CommonEntity {
   @JoinColumn({ referencedColumnName: 'id' })
   bundle?: ProductBundleEntity;
 
-  @OneToMany(() => ProductRequiredOptionEntity, (pro) => pro.productId)
+  @OneToMany(() => ProductRequiredOptionEntity, (pro) => pro.product)
   productRequiredOptions!: ProductRequiredOptionEntity[];
 
   @OneToMany(() => ProductOptionEntity, (po) => po.productId)

--- a/src/entities/product.entity.ts
+++ b/src/entities/product.entity.ts
@@ -73,12 +73,12 @@ export class ProductEntity extends CommonEntity {
   @OneToMany(() => ProductRequiredOptionEntity, (pro) => pro.product)
   productRequiredOptions!: ProductRequiredOptionEntity[];
 
-  @OneToMany(() => ProductOptionEntity, (po) => po.productId)
+  @OneToMany(() => ProductOptionEntity, (po) => po.product)
   productOptions!: ProductOptionEntity[];
 
-  @OneToMany(() => CartEntity, (c) => c.productId)
+  @OneToMany(() => CartEntity, (c) => c.product)
   carts!: CartEntity[];
 
-  @OneToMany(() => OrderProductEntity, (op) => op.productId)
+  @OneToMany(() => OrderProductEntity, (op) => op.product)
   orderProducts!: OrderProductEntity[];
 }

--- a/src/entities/seller.entity.ts
+++ b/src/entities/seller.entity.ts
@@ -29,9 +29,9 @@ export class SellerEntity extends CommonEntity {
   /**
    * relations
    */
-  @OneToMany(() => ProductBundleEntity, (pb) => pb.sellerId)
+  @OneToMany(() => ProductBundleEntity, (pb) => pb.seller)
   productBundles!: ProductBundleEntity[];
 
-  @OneToMany(() => ProductEntity, (p) => p.sellerId)
+  @OneToMany(() => ProductEntity, (p) => p.seller)
   products!: ProductEntity[];
 }

--- a/src/test/unit/product.spec.ts
+++ b/src/test/unit/product.spec.ts
@@ -279,6 +279,30 @@ describe('ProductController', () => {
     it.todo('상품 조회시 리뷰수가 노출되어야 한다.');
   });
 
+  describe('typeorm 조인 쿼리를 검증한다.', () => {
+    it('상품 조회시 필수 옵션에 대한 DB 조회를 할 수 있어야 한다.', async () => {
+      const ProductIds = products.map((el) => el.id);
+      const testId = ProductIds[0];
+
+      const data = await repository
+        .createQueryBuilder('product')
+        .withDeleted()
+        .innerJoinAndSelect('product.productRequiredOptions', 'productRequiredOption')
+        .where('product.id = :id', { id: testId })
+        .andWhere('product.isSale = :isSale', { isSale: true })
+        .andWhere('productRequiredOption.productId = :productId', { productId: testId })
+        .andWhere('productRequiredOption.isSale = :isSale', { isSale: true })
+        .getOne();
+
+      expect(data !== null).toBe(true);
+      if (data != null) {
+        expect(data.id).toBe(testId);
+        expect(data.isSale).toBe(true);
+        expect(data['productRequiredOptions'].every((el) => el.productId === testId)).toBe(true);
+      }
+    });
+  });
+
   /**
    * GET products/:id
    */


### PR DESCRIPTION
## Overview 

https://github.com/rimo030/nestjs-e-commerce-frame/pull/74#issuecomment-1857472066 을 바탕으로 모든 엔티티의 `relations`를 수정했습니다!

product와 product_required_option간  조인 테스트를 진행했고 통과하는 것을 확인 후

모든 `relations`에 반영하였습니다.

위 테스트에 대해 확인해 보았을 때 `name` 프로퍼티가 없어도 잘 작동이 되어  `name`추가없이 진행하려고 합니다.


