### PR TITLE
상품 API에서 엔티티 대신 DTO를 반환하도록 수정했습니다.

### DIFF
--- a/src/controllers/product.controller.ts
+++ b/src/controllers/product.controller.ts
@@ -1,7 +1,8 @@
 import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GetProductListPaginationDto } from 'src/entities/dtos/get-product-list-pagination.dto';
-import { GetProductOptionsDto } from 'src/entities/dtos/get-product-options.dto';
+import { GetProductOptionDto } from 'src/entities/dtos/get-product-options.dto';
+import { GetProductRequiredOptionDto } from 'src/entities/dtos/get-product-required-option.dto';
 import { IsRequireOptionDto } from 'src/entities/dtos/is-require-options.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
 import { GetProductListResponse } from 'src/interfaces/get-product-list-response.interface';
@@ -35,7 +36,7 @@ export class ProductController {
     @Param('id', ParseIntPipe) productId: number,
     @Query() isRequireOptionDto: IsRequireOptionDto,
     @Query() paginationDto: PaginationDto,
-  ): Promise<PaginationResponseForm<GetProductOptionsDto>> {
+  ): Promise<PaginationResponseForm<GetProductRequiredOptionDto | GetProductOptionDto>> {
     const response = await this.productService.getProductOptions(productId, isRequireOptionDto, paginationDto);
     return createResponseForm(response, paginationDto);
   }
@@ -46,7 +47,7 @@ export class ProductController {
     const [product, productRequiredOptions, productOptions] = await Promise.all([
       this.productService.getProduct(id),
       this.productService.getProductOptions(id, { isRequire: true }, { page: 1, limit: 10 }),
-      await this.productService.getProductOptions(id, { isRequire: false }, { page: 1, limit: 10 }),
+      this.productService.getProductOptions(id, { isRequire: false }, { page: 1, limit: 10 }),
     ]);
 
     return createResponseForm({ product, productRequiredOptions, productOptions });

--- a/src/controllers/product.controller.ts
+++ b/src/controllers/product.controller.ts
@@ -1,11 +1,9 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GetProductListPaginationDto } from 'src/entities/dtos/get-product-list-pagination.dto';
+import { GetProductOptionsDto } from 'src/entities/dtos/get-product-options.dto';
 import { IsRequireOptionDto } from 'src/entities/dtos/is-require-options.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
-import { ProductOptionEntity } from 'src/entities/product-option.entity';
-import { ProductRequiredOptionEntity } from 'src/entities/product-required-option.entity';
-import { ProductEntity } from 'src/entities/product.entity';
 import { GetProductListResponse } from 'src/interfaces/get-product-list-response.interface';
 import { GetProductResponse } from 'src/interfaces/get-product-response.interface';
 import { PaginationResponseForm } from 'src/interfaces/pagination-response-form.interface';
@@ -37,7 +35,7 @@ export class ProductController {
     @Param('id', ParseIntPipe) productId: number,
     @Query() isRequireOptionDto: IsRequireOptionDto,
     @Query() paginationDto: PaginationDto,
-  ): Promise<PaginationResponseForm<ProductRequiredOptionEntity | ProductOptionEntity>> {
+  ): Promise<PaginationResponseForm<GetProductOptionsDto>> {
     const response = await this.productService.getProductOptions(productId, isRequireOptionDto, paginationDto);
     return createResponseForm(response, paginationDto);
   }

--- a/src/controllers/product.controller.ts
+++ b/src/controllers/product.controller.ts
@@ -43,17 +43,12 @@ export class ProductController {
   @Get('/:id')
   @ApiOperation({ summary: '상품 상세 조회 API', description: '등록된 상품의 정보를 확인할 수 있다.' })
   async getProduct(@Param('id', ParseIntPipe) id: number): Promise<ResponseForm<GetProductResponse>> {
-    const product = await this.productService.getProduct(id);
-    const productRequiredOptions = await this.productService.getProductOptions(
-      id,
-      { isRequire: true },
-      { page: 1, limit: 10 },
-    );
-    const productOptions = await this.productService.getProductOptions(
-      id,
-      { isRequire: false },
-      { page: 1, limit: 10 },
-    );
+    const [product, productRequiredOptions, productOptions] = await Promise.all([
+      this.productService.getProduct(id),
+      this.productService.getProductOptions(id, { isRequire: true }, { page: 1, limit: 10 }),
+      await this.productService.getProductOptions(id, { isRequire: false }, { page: 1, limit: 10 }),
+    ]);
+
     return createResponseForm({ product, productRequiredOptions, productOptions });
   }
 

--- a/src/entities/dtos/create-product.dto.ts
+++ b/src/entities/dtos/create-product.dto.ts
@@ -13,9 +13,9 @@ export class CreateProductDto
     Partial<ProductEntity>,
     Pick<ProductEntity, 'categoryId' | 'companyId' | 'isSale' | 'name' | 'deliveryType' | 'deliveryCharge' | 'img'>
 {
-  @ApiProperty({ description: '묶음 배송 그룹 id' })
+  @ApiProperty({ description: '묶음 배송 그룹 id', required: false, nullable: true })
   @IsOptionalNumber()
-  bundleId?: number;
+  bundleId?: number | null;
 
   @ApiProperty({ description: '상품 카테고리 id' })
   @IsNotEmptyNumber()
@@ -33,7 +33,7 @@ export class CreateProductDto
   @IsNotEmptyString(1, 128)
   name!: string;
 
-  @ApiProperty({ description: '상품 설명', required: false })
+  @ApiProperty({ description: '상품 설명', required: false, nullable: true })
   @IsOptionalString(1, 128)
   description?: string | null;
 
@@ -44,7 +44,7 @@ export class CreateProductDto
   /**
    * deliveryType이 FREE | NOT_FREE 라면 null
    */
-  @ApiProperty({ description: '무료 배송 기준' })
+  @ApiProperty({ description: '무료 배송 기준', nullable: true })
   @IsOptionalNumber()
   deliveryFreeOver?: number | null;
 

--- a/src/entities/dtos/get-product-options.dto.ts
+++ b/src/entities/dtos/get-product-options.dto.ts
@@ -1,17 +1,10 @@
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { IsNotEmptyNumber } from 'src/decorators/is-not-empty-number.decorator';
-import { ProductRequiredOptionEntity } from '../product-required-option.entity';
-import { CreateProductOptionsDto } from './create-product-options.dto';
+import { PickType } from '@nestjs/swagger';
+import { ProductOptionEntity } from '../product-option.entity';
 
-export class GetProductOptionsDto
-  extends PickType(CreateProductOptionsDto, ['name', 'price', 'isSale'] as const)
-  implements Pick<ProductRequiredOptionEntity, 'id' | 'productId'>
-{
-  @ApiProperty({ description: '필수옵션 Id' })
-  @IsNotEmptyNumber('int')
-  id!: number;
-
-  @ApiProperty({ description: '상품 Id' })
-  @IsNotEmptyNumber('int')
-  productId!: number;
-}
+export class GetProductOptionDto extends PickType(ProductOptionEntity, [
+  'id',
+  'productId',
+  'name',
+  'price',
+  'isSale',
+] as const) {}

--- a/src/entities/dtos/get-product-options.dto.ts
+++ b/src/entities/dtos/get-product-options.dto.ts
@@ -1,11 +1,11 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmptyBoolean } from 'src/decorators/is-not-empty-boolean.decorator';
+import { ApiProperty, PickType } from '@nestjs/swagger';
 import { IsNotEmptyNumber } from 'src/decorators/is-not-empty-number.decorator';
-import { IsNotEmptyString } from 'src/decorators/is-not-empty-string.decorator';
 import { ProductRequiredOptionEntity } from '../product-required-option.entity';
+import { CreateProductOptionsDto } from './create-product-options.dto';
 
 export class GetProductOptionsDto
-  implements Pick<ProductRequiredOptionEntity, 'id' | 'productId' | 'name' | 'price' | 'isSale'>
+  extends PickType(CreateProductOptionsDto, ['name', 'price', 'isSale'] as const)
+  implements Pick<ProductRequiredOptionEntity, 'id' | 'productId'>
 {
   @ApiProperty({ description: '필수옵션 Id' })
   @IsNotEmptyNumber('int')
@@ -14,16 +14,4 @@ export class GetProductOptionsDto
   @ApiProperty({ description: '상품 Id' })
   @IsNotEmptyNumber('int')
   productId!: number;
-
-  @ApiProperty({ description: '옵션 이름' })
-  @IsNotEmptyString(1, 128)
-  name!: string;
-
-  @ApiProperty({ description: '가격' })
-  @IsNotEmptyNumber()
-  price!: number;
-
-  @ApiProperty({ description: '구매 가능 여부' })
-  @IsNotEmptyBoolean()
-  isSale!: boolean;
 }

--- a/src/entities/dtos/get-product-options.dto.ts
+++ b/src/entities/dtos/get-product-options.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmptyBoolean } from 'src/decorators/is-not-empty-boolean.decorator';
+import { IsNotEmptyNumber } from 'src/decorators/is-not-empty-number.decorator';
+import { IsNotEmptyString } from 'src/decorators/is-not-empty-string.decorator';
+import { ProductRequiredOptionEntity } from '../product-required-option.entity';
+
+export class GetProductOptionsDto
+  implements Pick<ProductRequiredOptionEntity, 'id' | 'productId' | 'name' | 'price' | 'isSale'>
+{
+  @ApiProperty({ description: '필수옵션 Id' })
+  @IsNotEmptyNumber('int')
+  id!: number;
+
+  @ApiProperty({ description: '상품 Id' })
+  @IsNotEmptyNumber('int')
+  productId!: number;
+
+  @ApiProperty({ description: '옵션 이름' })
+  @IsNotEmptyString(1, 128)
+  name!: string;
+
+  @ApiProperty({ description: '가격' })
+  @IsNotEmptyNumber()
+  price!: number;
+
+  @ApiProperty({ description: '구매 가능 여부' })
+  @IsNotEmptyBoolean()
+  isSale!: boolean;
+}

--- a/src/entities/dtos/get-product-required-option.dto.ts
+++ b/src/entities/dtos/get-product-required-option.dto.ts
@@ -1,0 +1,16 @@
+import { PickType } from '@nestjs/swagger';
+import { ProductInputOptionEntity } from '../product-input-option.entity';
+import { ProductRequiredOptionEntity } from '../product-required-option.entity';
+
+export class GetProductRequiredOptionDto extends PickType(ProductRequiredOptionEntity, [
+  'id',
+  'productId',
+  'name',
+  'price',
+  'isSale',
+] as const) {
+  productInputOptions!: Pick<
+    ProductInputOptionEntity,
+    'id' | 'productRequiredOptionId' | 'name' | 'value' | 'description' | 'isRequired'
+  >[];
+}

--- a/src/entities/dtos/get-product.dto.ts
+++ b/src/entities/dtos/get-product.dto.ts
@@ -1,0 +1,27 @@
+import { IsEnum } from 'class-validator';
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { IsNotEmptyBoolean } from 'src/decorators/is-not-empty-boolean.decorator';
+import { IsNotEmptyNumber } from 'src/decorators/is-not-empty-number.decorator';
+import { IsNotEmptyString } from 'src/decorators/is-not-empty-string.decorator';
+import { IsOptionalNumber } from 'src/decorators/is-optional-number.decorator';
+import { IsOptionalString } from 'src/decorators/is-optional-string.decorator';
+import { deliveryType } from 'src/types/enums/fee-type.enum';
+import { ProductEntity } from '../product.entity';
+import { CreateProductDto } from './create-product.dto';
+
+export class GetProductDto
+  extends PickType(CreateProductDto, [
+    'categoryId',
+    'companyId',
+    'isSale',
+    'name',
+    'deliveryType',
+    'deliveryCharge',
+    'img',
+  ] as const)
+  implements Pick<ProductEntity, 'id'>
+{
+  @ApiProperty({ description: '상품 Id' })
+  @IsNotEmptyNumber('int')
+  id!: number;
+}

--- a/src/entities/dtos/get-product.dto.ts
+++ b/src/entities/dtos/get-product.dto.ts
@@ -1,27 +1,13 @@
-import { IsEnum } from 'class-validator';
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { IsNotEmptyBoolean } from 'src/decorators/is-not-empty-boolean.decorator';
-import { IsNotEmptyNumber } from 'src/decorators/is-not-empty-number.decorator';
-import { IsNotEmptyString } from 'src/decorators/is-not-empty-string.decorator';
-import { IsOptionalNumber } from 'src/decorators/is-optional-number.decorator';
-import { IsOptionalString } from 'src/decorators/is-optional-string.decorator';
-import { deliveryType } from 'src/types/enums/fee-type.enum';
+import { PickType } from '@nestjs/swagger';
 import { ProductEntity } from '../product.entity';
-import { CreateProductDto } from './create-product.dto';
 
-export class GetProductDto
-  extends PickType(CreateProductDto, [
-    'categoryId',
-    'companyId',
-    'isSale',
-    'name',
-    'deliveryType',
-    'deliveryCharge',
-    'img',
-  ] as const)
-  implements Pick<ProductEntity, 'id'>
-{
-  @ApiProperty({ description: '상품 Id' })
-  @IsNotEmptyNumber('int')
-  id!: number;
-}
+export class GetProductDto extends PickType(ProductEntity, [
+  'id',
+  'categoryId',
+  'companyId',
+  'isSale',
+  'name',
+  'deliveryType',
+  'deliveryCharge',
+  'img',
+] as const) {}

--- a/src/interfaces/get-product-response.interface.ts
+++ b/src/interfaces/get-product-response.interface.ts
@@ -1,9 +1,10 @@
-import { GetProductOptionsDto } from 'src/entities/dtos/get-product-options.dto';
+import { GetProductOptionDto } from 'src/entities/dtos/get-product-options.dto';
+import { GetProductRequiredOptionDto } from 'src/entities/dtos/get-product-required-option.dto';
 import { GetProductDto } from 'src/entities/dtos/get-product.dto';
 import { GetResponse } from './get-response.interface';
 
 export interface GetProductResponse {
   product: GetProductDto;
-  productRequiredOptions: GetResponse<GetProductOptionsDto>;
-  productOptions: GetResponse<GetProductOptionsDto>;
+  productRequiredOptions: GetResponse<GetProductRequiredOptionDto>;
+  productOptions: GetResponse<GetProductOptionDto>;
 }

--- a/src/interfaces/get-product-response.interface.ts
+++ b/src/interfaces/get-product-response.interface.ts
@@ -1,10 +1,9 @@
-import { ProductOptionEntity } from 'src/entities/product-option.entity';
-import { ProductRequiredOptionEntity } from 'src/entities/product-required-option.entity';
-import { ProductEntity } from 'src/entities/product.entity';
+import { GetProductOptionsDto } from 'src/entities/dtos/get-product-options.dto';
+import { GetProductDto } from 'src/entities/dtos/get-product.dto';
 import { GetResponse } from './get-response.interface';
 
 export interface GetProductResponse {
-  product: ProductEntity;
-  productRequiredOptions: GetResponse<ProductRequiredOptionEntity>;
-  productOptions: GetResponse<ProductOptionEntity>;
+  product: GetProductDto;
+  productRequiredOptions: GetResponse<GetProductOptionsDto>;
+  productOptions: GetResponse<GetProductOptionsDto>;
 }

--- a/src/services/product.service.ts
+++ b/src/services/product.service.ts
@@ -3,10 +3,10 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreateProductDto } from 'src/entities/dtos/create-product.dto';
 import { GetProductListPaginationDto } from 'src/entities/dtos/get-product-list-pagination.dto';
-import { GetProductOptionsDto } from 'src/entities/dtos/get-product-options.dto';
+import { GetProductOptionDto } from 'src/entities/dtos/get-product-options.dto';
+import { GetProductRequiredOptionDto } from 'src/entities/dtos/get-product-required-option.dto';
 import { IsRequireOptionDto } from 'src/entities/dtos/is-require-options.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
-// import { ProductEntity } from 'src/entities/product.entity';
 import { GetResponse } from 'src/interfaces/get-response.interface';
 import { ProductElement } from 'src/interfaces/product-element.interface';
 import { ProductInputOptionRepository } from 'src/repositories/product.input.option.repository';
@@ -102,7 +102,7 @@ export class ProductService {
     productId: number,
     isRequireOptionDto: IsRequireOptionDto,
     paginationDto: PaginationDto,
-  ): Promise<GetResponse<GetProductOptionsDto>> {
+  ): Promise<GetResponse<GetProductRequiredOptionDto | GetProductOptionDto>> {
     const { isRequire } = isRequireOptionDto;
     const { skip, take } = getOffset(paginationDto);
 
@@ -114,6 +114,14 @@ export class ProductService {
           name: true,
           price: true,
           isSale: true,
+          productInputOptions: {
+            id: true,
+            productRequiredOptionId: true,
+            name: true,
+            value: true,
+            description: true,
+            isRequired: true,
+          },
         },
         order: {
           id: 'ASC',

--- a/src/services/product.service.ts
+++ b/src/services/product.service.ts
@@ -1,12 +1,12 @@
 import { ILike } from 'typeorm';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { CreateProductDto } from 'src/entities/dtos/create-product.dto';
 import { GetProductListPaginationDto } from 'src/entities/dtos/get-product-list-pagination.dto';
+import { GetProductOptionsDto } from 'src/entities/dtos/get-product-options.dto';
 import { IsRequireOptionDto } from 'src/entities/dtos/is-require-options.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
-import { ProductOptionEntity } from 'src/entities/product-option.entity';
-import { ProductRequiredOptionEntity } from 'src/entities/product-required-option.entity';
-import { ProductEntity } from 'src/entities/product.entity';
+// import { ProductEntity } from 'src/entities/product.entity';
 import { GetResponse } from 'src/interfaces/get-response.interface';
 import { ProductElement } from 'src/interfaces/product-element.interface';
 import { ProductInputOptionRepository } from 'src/repositories/product.input.option.repository';
@@ -31,8 +31,21 @@ export class ProductService {
     private readonly productInputOptionRepository: ProductInputOptionRepository,
   ) {}
 
-  async getProduct(id: number): Promise<ProductEntity> {
+  async getProduct(id: number): Promise<CreateProductDto> {
     const product = await this.productRepository.findOne({
+      select: {
+        id: true,
+        bundleId: true,
+        categoryId: true,
+        companyId: true,
+        isSale: true,
+        name: true,
+        description: true,
+        deliveryType: true,
+        deliveryFreeOver: true,
+        deliveryCharge: true,
+        img: true,
+      },
       where: {
         id,
       },
@@ -89,16 +102,23 @@ export class ProductService {
     productId: number,
     isRequireOptionDto: IsRequireOptionDto,
     paginationDto: PaginationDto,
-  ): Promise<GetResponse<ProductRequiredOptionEntity | ProductOptionEntity>> {
+  ): Promise<GetResponse<GetProductOptionsDto>> {
     const { isRequire } = isRequireOptionDto;
     const { skip, take } = getOffset(paginationDto);
 
     if (isRequire) {
       const [list, count] = await this.productRequiredOptionRepository.findAndCount({
+        select: {
+          id: true,
+          productId: true,
+          name: true,
+          price: true,
+          isSale: true,
+        },
         order: {
           id: 'ASC',
         },
-        relations: ['productInputOptions'],
+        relations: { productInputOptions: true },
         where: {
           productId,
           isSale: true,
@@ -112,6 +132,13 @@ export class ProductService {
       throw new NotFoundException(`There is no required option for product ${productId}.`);
     } else {
       const [list, count] = await this.productOptionRepository.findAndCount({
+        select: {
+          id: true,
+          productId: true,
+          name: true,
+          price: true,
+          isSale: true,
+        },
         order: {
           id: 'ASC',
         },

--- a/src/test/unit/product.spec.ts
+++ b/src/test/unit/product.spec.ts
@@ -541,9 +541,9 @@ describe('ProductController', () => {
            * productRequiredId가 짝수인 경우에 입력옵션을 가지고 홀수라면 입력옵션을 가지지 않는다.
            */
           if (pro.id % 2 === 0) {
-            expect(pro['productInputOptions'].every((pio) => pio.productRequiredOptionId === pro.id)).toBe(true);
+            expect(pro.productInputOptions.every((pio) => pio.productRequiredOptionId === pro.id)).toBe(true);
           } else {
-            expect(pro['productInputOptions'].length).toBe(0);
+            expect(pro.productInputOptions.length).toBe(0);
           }
         });
       }

--- a/src/test/unit/product.spec.ts
+++ b/src/test/unit/product.spec.ts
@@ -3,6 +3,7 @@ import { AppModule } from 'src/app.module';
 import { ProductController } from 'src/controllers/product.controller';
 import { CategoryEntity } from 'src/entities/category.entity';
 import { CompanyEntity } from 'src/entities/company.entity';
+import { GetProductDto } from 'src/entities/dtos/get-product.dto';
 import { ProductInputOptionEntity } from 'src/entities/product-input-option.entity';
 import { ProductOptionEntity } from 'src/entities/product-option.entity';
 import { ProductRequiredOptionEntity } from 'src/entities/product-required-option.entity';
@@ -149,7 +150,7 @@ describe('ProductController', () => {
           new ProductRequiredOptionEntity({
             productId: p.id,
             name: `test_${p.id}_${i}`,
-            price: i * 1000 + 100,
+            price: i * 1000 + MinPrice,
             isSale: true,
           }),
         );
@@ -390,7 +391,7 @@ describe('ProductController', () => {
     /**
      * 상품의 최초 조회 시 상품의 옵션들이 조회되기 때문에 서비스 로직은 재사용될 수 있어야 한다.
      */
-    it('상품의 상세 페이지를 조회할 수 있어야한다.', async () => {
+    it.only('상품의 상세 페이지를 조회할 수 있어야한다.', async () => {
       const ProductIds = products.map((el) => el.id);
       const testId = ProductIds[0];
 
@@ -428,6 +429,7 @@ describe('ProductController', () => {
         { isRequire: false },
         { page: 0, limit: testMinCount },
       );
+
       /**
        * 페이지네이션으로 조회된 상품 필수/선택옵션의 id는 testId와 같아야 한다.
        */

--- a/src/test/unit/product.spec.ts
+++ b/src/test/unit/product.spec.ts
@@ -391,7 +391,7 @@ describe('ProductController', () => {
     /**
      * 상품의 최초 조회 시 상품의 옵션들이 조회되기 때문에 서비스 로직은 재사용될 수 있어야 한다.
      */
-    it.only('상품의 상세 페이지를 조회할 수 있어야한다.', async () => {
+    it('상품의 상세 페이지를 조회할 수 있어야한다.', async () => {
       const ProductIds = products.map((el) => el.id);
       const testId = ProductIds[0];
 


### PR DESCRIPTION
## OverView 
https://github.com/rimo030/nestjs-e-commerce-frame/pull/77#discussion_r1430336901 에 달아주신대로 엔티티를 그대로 담아 내보내는것은 문제라고 생각해 수정하였습니다.

DTO를 사용해 도메인의 핵심 로직과 속성은 내부로 숨기고, 불필요한 데이터 전달을 방지하고자 합니다.

## Implementations
아래 두 개 Dto를 정의했습니다.

- GetProductOptionsDto
- GetproductDto

기존의 엔티티를 반환하던 코드를 DTO로 변경하였습니다.

변경후 작성되어 있었던 모든 테스트를 통과하는 것을 확인했습니다. 