### PR TITLE
API의 서비스에서 레포지토리 로직을 분리했습니다!

### DIFF
--- a/src/controllers/category.controller.ts
+++ b/src/controllers/category.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { CategoryEntity } from 'src/entities/category.entity';
+import { GetCategoryDto } from 'src/entities/dtos/get-category.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
 import { PaginationResponseForm } from 'src/interfaces/pagination-response-form.interface';
 import { CategoryService } from 'src/services/category.service';
@@ -13,7 +14,7 @@ export class CategoryController {
 
   @Get()
   @ApiOperation({ summary: '카테고리 조회 API', description: '등록된 카테고리를 확인할 수 있다.' })
-  async getCategory(@Query() paginationDto: PaginationDto): Promise<PaginationResponseForm<CategoryEntity>> {
+  async getCategory(@Query() paginationDto: PaginationDto): Promise<PaginationResponseForm<GetCategoryDto>> {
     const response = await this.categoryService.getCategory(paginationDto);
     return createResponseForm(response, paginationDto);
   }

--- a/src/controllers/company.controller.ts
+++ b/src/controllers/company.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { SellerJwtAuthGuard } from 'src/auth/guards/seller-jwt.guard';
 import { UserId } from 'src/decorators/user-id.decorator';
 import { CompanyEntity } from 'src/entities/company.entity';
+import { GetCompanyDto } from 'src/entities/dtos/get-company.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
 import { PaginationResponseForm } from 'src/interfaces/pagination-response-form.interface';
 import { CompanyService } from 'src/services/company.service';
@@ -22,7 +23,7 @@ export class CompanyController {
      */
     // @UserId() sellerId: number,
     @Query() paginationDto: PaginationDto,
-  ): Promise<PaginationResponseForm<CompanyEntity>> {
+  ): Promise<PaginationResponseForm<GetCompanyDto>> {
     const response = await this.companyService.getCompany(paginationDto);
     return createResponseForm(response, paginationDto);
   }

--- a/src/controllers/seller.controller.ts
+++ b/src/controllers/seller.controller.ts
@@ -7,6 +7,7 @@ import { CreateProductOptionsDto } from 'src/entities/dtos/create-product-option
 import { CreateProductDto } from 'src/entities/dtos/create-product.dto';
 import { GetProductOptionDto } from 'src/entities/dtos/get-product-options.dto';
 import { GetProductRequiredOptionDto } from 'src/entities/dtos/get-product-required-option.dto';
+import { GetProductDto } from 'src/entities/dtos/get-product.dto';
 import { IsRequireOptionDto } from 'src/entities/dtos/is-require-options.dto';
 import { ProductOptionEntity } from 'src/entities/product-option.entity';
 import { ProductRequiredOptionEntity } from 'src/entities/product-required-option.entity';
@@ -30,14 +31,14 @@ export class SellerController {
 
   @Post('/product')
   @ApiOperation({ summary: 'product 등록 API', description: 'seller는 상품을 등록할 수 있다.' })
-  async createProduct(@UserId() sellerId: number, @Body() createProductDto: CreateProductDto): Promise<ProductEntity> {
+  async createProduct(@UserId() sellerId: number, @Body() createProductDto: CreateProductDto): Promise<GetProductDto> {
     return await this.sellerservice.createProduct(sellerId, createProductDto);
   }
 
   @Post('/product/:id/options')
   @ApiOperation({
     summary: 'product 옵션, 선택옵션 등록 API',
-    description: 'seller는 상품의 옵션과 선택옵션을 등록할 수 있다.',
+    description: 'seller는 상품의 옵션과 선택 옵션을 등록할 수 있다.',
   })
   async createProductOptions(
     @UserId() sellerId: number,

--- a/src/controllers/seller.controller.ts
+++ b/src/controllers/seller.controller.ts
@@ -5,6 +5,8 @@ import { UserId } from 'src/decorators/user-id.decorator';
 import { CreateProductBundleDto } from 'src/entities/dtos/create-product-bundle.dto';
 import { CreateProductOptionsDto } from 'src/entities/dtos/create-product-options.dto';
 import { CreateProductDto } from 'src/entities/dtos/create-product.dto';
+import { GetProductOptionDto } from 'src/entities/dtos/get-product-options.dto';
+import { GetProductRequiredOptionDto } from 'src/entities/dtos/get-product-required-option.dto';
 import { IsRequireOptionDto } from 'src/entities/dtos/is-require-options.dto';
 import { ProductOptionEntity } from 'src/entities/product-option.entity';
 import { ProductRequiredOptionEntity } from 'src/entities/product-required-option.entity';
@@ -42,7 +44,7 @@ export class SellerController {
     @Param('id', ParseIntPipe) productId: number,
     @Query() isRequireOptionDto: IsRequireOptionDto,
     @Body() createProductOptionsDto: CreateProductOptionsDto,
-  ): Promise<ProductRequiredOptionEntity | ProductOptionEntity> {
+  ): Promise<GetProductRequiredOptionDto | GetProductOptionDto> {
     return await this.sellerservice.createProductOptions(
       sellerId,
       productId,

--- a/src/controllers/seller.controller.ts
+++ b/src/controllers/seller.controller.ts
@@ -5,6 +5,7 @@ import { UserId } from 'src/decorators/user-id.decorator';
 import { CreateProductBundleDto } from 'src/entities/dtos/create-product-bundle.dto';
 import { CreateProductOptionsDto } from 'src/entities/dtos/create-product-options.dto';
 import { CreateProductDto } from 'src/entities/dtos/create-product.dto';
+import { GetProductBundleDto } from 'src/entities/dtos/get-product-bundle.dto';
 import { GetProductOptionDto } from 'src/entities/dtos/get-product-options.dto';
 import { GetProductRequiredOptionDto } from 'src/entities/dtos/get-product-required-option.dto';
 import { GetProductDto } from 'src/entities/dtos/get-product.dto';
@@ -25,8 +26,8 @@ export class SellerController {
   async createProductBundle(
     @UserId() sellerId: number,
     @Body() createProductBundleDto: CreateProductBundleDto,
-  ): Promise<void> {
-    await this.sellerservice.createProductBundle(sellerId, createProductBundleDto);
+  ): Promise<GetProductBundleDto> {
+    return await this.sellerservice.createProductBundle(sellerId, createProductBundleDto);
   }
 
   @Post('/product')

--- a/src/entities/dtos/get-category.dto.ts
+++ b/src/entities/dtos/get-category.dto.ts
@@ -1,0 +1,4 @@
+import { PickType } from '@nestjs/swagger';
+import { CategoryEntity } from '../category.entity';
+
+export class GetCategoryDto extends PickType(CategoryEntity, ['id', 'name']) {}

--- a/src/entities/dtos/get-company.dto.ts
+++ b/src/entities/dtos/get-company.dto.ts
@@ -1,0 +1,4 @@
+import { PickType } from '@nestjs/swagger';
+import { CompanyEntity } from '../company.entity';
+
+export class GetCompanyDto extends PickType(CompanyEntity, ['id', 'name']) {}

--- a/src/entities/dtos/get-product-bundle.dto.ts
+++ b/src/entities/dtos/get-product-bundle.dto.ts
@@ -1,0 +1,4 @@
+import { PickType } from '@nestjs/swagger';
+import { ProductBundleEntity } from '../product-bundle.entity';
+
+export class GetProductBundleDto extends PickType(ProductBundleEntity, ['id', 'name', 'chargeStandard']) {}

--- a/src/entities/dtos/get-product.dto.ts
+++ b/src/entities/dtos/get-product.dto.ts
@@ -3,6 +3,7 @@ import { ProductEntity } from '../product.entity';
 
 export class GetProductDto extends PickType(ProductEntity, [
   'id',
+  'sellerId',
   'categoryId',
   'companyId',
   'isSale',

--- a/src/entities/dtos/get-product.dto.ts
+++ b/src/entities/dtos/get-product.dto.ts
@@ -4,6 +4,7 @@ import { ProductEntity } from '../product.entity';
 export class GetProductDto extends PickType(ProductEntity, [
   'id',
   'sellerId',
+  'bundleId',
   'categoryId',
   'companyId',
   'isSale',

--- a/src/interfaces/get-product-list-response.interface.ts
+++ b/src/interfaces/get-product-list-response.interface.ts
@@ -1,9 +1,9 @@
 import { GetProductListPaginationDto } from 'src/entities/dtos/get-product-list-pagination.dto';
-import { ProductElement } from './product-element.interface';
+import { ProductListElement } from './product-list-element.interface';
 
 export interface GetProductListResponse {
   data: {
-    list: ProductElement[];
+    list: ProductListElement[];
     totalPage: number;
     /**
      * 스크롤 기반에서 사용하기 위해서 마지막 상품 아이디를 제공한다.

--- a/src/interfaces/product-element.interface.ts
+++ b/src/interfaces/product-element.interface.ts
@@ -1,7 +1,7 @@
 import { ProductEntity } from 'src/entities/product.entity';
 
 export interface ProductElement
-  extends Pick<ProductEntity, 'id' | 'categoryId' | 'companyId' | 'name' | 'deliveryType' | 'img'> {
+  extends Pick<ProductEntity, 'id' | 'sellerId' | 'categoryId' | 'companyId' | 'name' | 'deliveryType' | 'img'> {
   salePrice: number;
 
   /**

--- a/src/interfaces/product-element.interface.ts
+++ b/src/interfaces/product-element.interface.ts
@@ -1,7 +1,19 @@
 import { ProductEntity } from 'src/entities/product.entity';
 
 export interface ProductElement
-  extends Pick<ProductEntity, 'id' | 'sellerId' | 'categoryId' | 'companyId' | 'name' | 'deliveryType' | 'img'> {
+  extends Pick<
+    ProductEntity,
+    | 'id'
+    | 'sellerId'
+    | 'bundleId'
+    | 'categoryId'
+    | 'companyId'
+    | 'isSale'
+    | 'name'
+    | 'deliveryType'
+    | 'deliveryCharge'
+    | 'img'
+  > {
   salePrice: number;
 
   /**

--- a/src/interfaces/product-list-element.interface.ts
+++ b/src/interfaces/product-list-element.interface.ts
@@ -1,19 +1,7 @@
 import { ProductEntity } from 'src/entities/product.entity';
 
-export interface ProductElement
-  extends Pick<
-    ProductEntity,
-    | 'id'
-    | 'sellerId'
-    | 'bundleId'
-    | 'categoryId'
-    | 'companyId'
-    | 'isSale'
-    | 'name'
-    | 'deliveryType'
-    | 'deliveryCharge'
-    | 'img'
-  > {
+export interface ProductListElement
+  extends Pick<ProductEntity, 'id' | 'sellerId' | 'categoryId' | 'companyId' | 'name' | 'deliveryType' | 'img'> {
   salePrice: number;
 
   /**

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -1,6 +1,22 @@
 import { Repository } from 'typeorm';
 import { CategoryEntity } from 'src/entities/category.entity';
+import { GetCategoryDto } from 'src/entities/dtos/get-category.dto';
 import { CustomRepository } from '../configs/custom-typeorm.decorator';
 
 @CustomRepository(CategoryEntity)
-export class CategoryRepository extends Repository<CategoryEntity> {}
+export class CategoryRepository extends Repository<CategoryEntity> {
+  async getCategory(skip: number, take: number): Promise<[GetCategoryDto[], number]> {
+    return await this.findAndCount({
+      select: {
+        id: true,
+        name: true,
+      },
+      order: {
+        name: 'ASC',
+        id: 'ASC',
+      },
+      skip,
+      take,
+    });
+  }
+}

--- a/src/repositories/company.repository.ts
+++ b/src/repositories/company.repository.ts
@@ -1,6 +1,18 @@
 import { Repository } from 'typeorm';
 import { CompanyEntity } from 'src/entities/company.entity';
+import { GetCompanyDto } from 'src/entities/dtos/get-company.dto';
 import { CustomRepository } from '../configs/custom-typeorm.decorator';
 
 @CustomRepository(CompanyEntity)
-export class CompanyRepository extends Repository<CompanyEntity> {}
+export class CompanyRepository extends Repository<CompanyEntity> {
+  async getCompany(skip: number, take: number): Promise<[GetCompanyDto[], number]> {
+    return await this.findAndCount({
+      order: {
+        name: 'ASC',
+        id: 'ASC',
+      },
+      skip,
+      take,
+    });
+  }
+}

--- a/src/repositories/product-bundle.repository.ts
+++ b/src/repositories/product-bundle.repository.ts
@@ -1,6 +1,26 @@
 import { Repository } from 'typeorm';
+import { CreateProductBundleDto } from 'src/entities/dtos/create-product-bundle.dto';
+import { GetProductBundleDto } from 'src/entities/dtos/get-product-bundle.dto';
 import { ProductBundleEntity } from 'src/entities/product-bundle.entity';
 import { CustomRepository } from '../configs/custom-typeorm.decorator';
 
 @CustomRepository(ProductBundleEntity)
-export class ProductBundleRepository extends Repository<ProductBundleEntity> {}
+export class ProductBundleRepository extends Repository<ProductBundleEntity> {
+  async createProductBundle(sellerId: number, createProductBundleDto: CreateProductBundleDto): Promise<{ id: number }> {
+    const { id, ...other } = await this.save({ sellerId, ...createProductBundleDto });
+    return { id };
+  }
+
+  async getProductBundle(id: number): Promise<GetProductBundleDto | null> {
+    return this.findOne({
+      select: {
+        id: true,
+        name: true,
+        chargeStandard: true,
+      },
+      where: {
+        id,
+      },
+    });
+  }
+}

--- a/src/repositories/product-option-repository.ts
+++ b/src/repositories/product-option-repository.ts
@@ -1,10 +1,31 @@
 import { Repository } from 'typeorm';
+import { CreateProductOptionsDto } from 'src/entities/dtos/create-product-options.dto';
 import { GetProductOptionDto } from 'src/entities/dtos/get-product-options.dto';
 import { ProductOptionEntity } from 'src/entities/product-option.entity';
 import { CustomRepository } from '../configs/custom-typeorm.decorator';
 
 @CustomRepository(ProductOptionEntity)
 export class ProductOptionRepository extends Repository<ProductOptionEntity> {
+  async createOption(productId: number, createProductOptionsDto: CreateProductOptionsDto): Promise<{ id: number }> {
+    const { id, ...other } = await this.save({ productId, ...createProductOptionsDto });
+    return { id };
+  }
+
+  async getOption(id: number): Promise<GetProductOptionDto | null> {
+    return await this.findOne({
+      select: {
+        id: true,
+        productId: true,
+        name: true,
+        price: true,
+        isSale: true,
+      },
+      where: {
+        id,
+      },
+    });
+  }
+
   async getProductOptions(productId: number, skip: number, take: number): Promise<[GetProductOptionDto[], number]> {
     return await this.findAndCount({
       select: {

--- a/src/repositories/product-required-option.repository.ts
+++ b/src/repositories/product-required-option.repository.ts
@@ -1,10 +1,35 @@
 import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { CreateProductOptionsDto } from 'src/entities/dtos/create-product-options.dto';
 import { GetProductRequiredOptionDto } from 'src/entities/dtos/get-product-required-option.dto';
 import { ProductRequiredOptionEntity } from 'src/entities/product-required-option.entity';
 import { CustomRepository } from '../configs/custom-typeorm.decorator';
 
 @CustomRepository(ProductRequiredOptionEntity)
 export class ProductRequiredOptionRepository extends Repository<ProductRequiredOptionEntity> {
+  async createRequiredOption(
+    productId: number,
+    createProductOptionsDto: CreateProductOptionsDto,
+  ): Promise<{ id: number }> {
+    const { id, ...other } = await this.save({ productId, ...createProductOptionsDto });
+    return { id };
+  }
+
+  async getRequiredOption(id: number): Promise<GetProductRequiredOptionDto | null> {
+    return await this.findOne({
+      select: {
+        id: true,
+        productId: true,
+        name: true,
+        price: true,
+        isSale: true,
+      },
+      where: {
+        id,
+      },
+    });
+  }
+
   async getMiniumPriceRows(productIds: number[]): Promise<{ productId: number; minimumPrice: number }[]> {
     return await this.createQueryBuilder('pro')
       .select('pro.productId as productId')

--- a/src/repositories/product.repository.ts
+++ b/src/repositories/product.repository.ts
@@ -1,4 +1,5 @@
 import { Repository, ILike } from 'typeorm';
+import { CreateProductDto } from 'src/entities/dtos/create-product.dto';
 import { GetProductDto } from 'src/entities/dtos/get-product.dto';
 import { ProductEntity } from 'src/entities/product.entity';
 import { ProductElement } from 'src/interfaces/product-element.interface';
@@ -6,10 +7,16 @@ import { CustomRepository } from '../configs/custom-typeorm.decorator';
 
 @CustomRepository(ProductEntity)
 export class ProductRepository extends Repository<ProductEntity> {
+  async createProduct(sellerId: number, createProductDto: CreateProductDto): Promise<{ id: number }> {
+    const { id, ...other } = await this.save({ sellerId, ...createProductDto });
+    return { id };
+  }
+
   async getProduct(id: number): Promise<GetProductDto | null> {
     return await this.findOne({
       select: {
         id: true,
+        sellerId: true,
         bundleId: true,
         categoryId: true,
         companyId: true,

--- a/src/repositories/product.repository.ts
+++ b/src/repositories/product.repository.ts
@@ -2,7 +2,7 @@ import { Repository, ILike } from 'typeorm';
 import { CreateProductDto } from 'src/entities/dtos/create-product.dto';
 import { GetProductDto } from 'src/entities/dtos/get-product.dto';
 import { ProductEntity } from 'src/entities/product.entity';
-import { ProductElement } from 'src/interfaces/product-element.interface';
+import { ProductListElement } from 'src/interfaces/product-list-element.interface';
 import { CustomRepository } from '../configs/custom-typeorm.decorator';
 
 @CustomRepository(ProductEntity)
@@ -40,10 +40,11 @@ export class ProductRepository extends Repository<ProductEntity> {
     sellerId: number | undefined | null,
     skip: number,
     take: number,
-  ): Promise<[Omit<ProductElement, 'salePrice'>[], number]> {
+  ): Promise<[Omit<ProductListElement, 'salePrice'>[], number]> {
     return await this.findAndCount({
       select: {
         id: true,
+        sellerId: true,
         categoryId: true,
         companyId: true,
         name: true,

--- a/src/services/category.service.ts
+++ b/src/services/category.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { CategoryEntity } from 'src/entities/category.entity';
+import { GetCategoryDto } from 'src/entities/dtos/get-category.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
 import { GetResponse } from 'src/interfaces/get-response.interface';
-import { PaginationResponseForm } from 'src/interfaces/pagination-response-form.interface';
 import { CategoryRepository } from 'src/repositories/category.repository';
 import { getOffset } from 'src/util/functions/get-offset.function';
 
@@ -11,16 +10,9 @@ export class CategoryService {
   companyRepository: any;
   constructor(private readonly categoryRepository: CategoryRepository) {}
 
-  async getCategory(paginationDto: PaginationDto): Promise<GetResponse<CategoryEntity>> {
+  async getCategory(paginationDto: PaginationDto): Promise<GetResponse<GetCategoryDto>> {
     const { skip, take } = getOffset(paginationDto);
-    const [list, count] = await this.categoryRepository.findAndCount({
-      order: {
-        name: 'ASC',
-        id: 'ASC',
-      },
-      skip,
-      take,
-    });
+    const [list, count] = await this.categoryRepository.getCategory(skip, take);
     return { list, count, take };
   }
 }

--- a/src/services/company.service.ts
+++ b/src/services/company.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { CompanyEntity } from 'src/entities/company.entity';
+import { GetCompanyDto } from 'src/entities/dtos/get-company.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
 import { GetResponse } from 'src/interfaces/get-response.interface';
 import { CompanyRepository } from 'src/repositories/company.repository';
@@ -13,16 +13,9 @@ export class CompanyService {
     private readonly companyRepository: CompanyRepository,
   ) {}
 
-  async getCompany(paginationDto: PaginationDto): Promise<GetResponse<CompanyEntity>> {
+  async getCompany(paginationDto: PaginationDto): Promise<GetResponse<GetCompanyDto>> {
     const { skip, take } = getOffset(paginationDto);
-    const [list, count] = await this.companyRepository.findAndCount({
-      order: {
-        name: 'ASC',
-        id: 'ASC',
-      },
-      skip,
-      take,
-    });
+    const [list, count] = await this.companyRepository.getCompany(skip, take);
     return { list, count, take };
   }
 }

--- a/src/services/product.service.ts
+++ b/src/services/product.service.ts
@@ -8,7 +8,7 @@ import { GetProductRequiredOptionDto } from 'src/entities/dtos/get-product-requi
 import { IsRequireOptionDto } from 'src/entities/dtos/is-require-options.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
 import { GetResponse } from 'src/interfaces/get-response.interface';
-import { ProductElement } from 'src/interfaces/product-element.interface';
+import { ProductListElement } from 'src/interfaces/product-list-element.interface';
 import { ProductInputOptionRepository } from 'src/repositories/product-input-option.repository';
 import { ProductOptionRepository } from 'src/repositories/product-option-repository';
 import { ProductRequiredOptionRepository } from 'src/repositories/product-required-option.repository';
@@ -38,7 +38,7 @@ export class ProductService {
     return product;
   }
 
-  async getProductList(dto: GetProductListPaginationDto): Promise<GetResponse<ProductElement>> {
+  async getProductList(dto: GetProductListPaginationDto): Promise<GetResponse<ProductListElement>> {
     const { page, limit, search, categoryId, sellerId } = dto;
     const { skip, take } = getOffset({ page, limit });
     const [products, count] = await this.productRepository.getProductList(search, categoryId, sellerId, skip, take);

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -42,11 +42,7 @@ export class SellerService {
     isRequireOptionDto: IsRequireOptionDto,
     createProductOptionsDto: CreateProductOptionsDto,
   ): Promise<ProductOptionEntity | ProductRequiredOptionEntity> {
-    const product = await this.productRepository.findOne({
-      where: {
-        id: productId,
-      },
-    });
+    const product = await this.productRepository.getProduct(productId);
 
     if (!product?.id) {
       throw new NotFoundException(`Can't find product id : ${productId}`);

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { CreateProductBundleDto } from 'src/entities/dtos/create-product-bundle.dto';
 import { CreateProductOptionsDto } from 'src/entities/dtos/create-product-options.dto';
 import { CreateProductDto } from 'src/entities/dtos/create-product.dto';
+import { GetProductBundleDto } from 'src/entities/dtos/get-product-bundle.dto';
 import { GetProductOptionDto } from 'src/entities/dtos/get-product-options.dto';
 import { GetProductRequiredOptionDto } from 'src/entities/dtos/get-product-required-option.dto';
 import { GetProductDto } from 'src/entities/dtos/get-product.dto';
@@ -31,8 +32,17 @@ export class SellerService {
     private readonly productOptionRepository: ProductOptionRepository,
   ) {}
 
-  async createProductBundle(sellerId: number, createProductBundleDto: CreateProductBundleDto): Promise<void> {
-    await this.productBundleRepository.save({ sellerId, ...createProductBundleDto });
+  async createProductBundle(
+    sellerId: number,
+    createProductBundleDto: CreateProductBundleDto,
+  ): Promise<GetProductBundleDto> {
+    const { id } = await this.productBundleRepository.createProductBundle(sellerId, createProductBundleDto);
+
+    const savedProductBundle = await this.productBundleRepository.getProductBundle(id);
+    if (!savedProductBundle) {
+      throw new NotFoundException(`Product Bundle Save failed `);
+    }
+    return savedProductBundle;
   }
 
   async createProduct(sellerId: number, createProductDto: CreateProductDto): Promise<GetProductDto> {
@@ -58,6 +68,8 @@ export class SellerService {
       throw new NotFoundException(`Can't find product id : ${productId}`);
     }
 
+    console.log(product?.sellerId);
+    console.log(sellerId);
     if (product?.sellerId !== sellerId) {
       throw new UnauthorizedException('You are not seller of this product.');
     }

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -5,6 +5,7 @@ import { CreateProductOptionsDto } from 'src/entities/dtos/create-product-option
 import { CreateProductDto } from 'src/entities/dtos/create-product.dto';
 import { GetProductOptionDto } from 'src/entities/dtos/get-product-options.dto';
 import { GetProductRequiredOptionDto } from 'src/entities/dtos/get-product-required-option.dto';
+import { GetProductDto } from 'src/entities/dtos/get-product.dto';
 import { IsRequireOptionDto } from 'src/entities/dtos/is-require-options.dto';
 import { ProductOptionEntity } from 'src/entities/product-option.entity';
 import { ProductRequiredOptionEntity } from 'src/entities/product-required-option.entity';
@@ -34,8 +35,15 @@ export class SellerService {
     await this.productBundleRepository.save({ sellerId, ...createProductBundleDto });
   }
 
-  async createProduct(sellerId: number, createProductDto: CreateProductDto): Promise<ProductEntity> {
-    return await this.productRepository.save({ sellerId, ...createProductDto });
+  async createProduct(sellerId: number, createProductDto: CreateProductDto): Promise<GetProductDto> {
+    const { id } = await this.productRepository.createProduct(sellerId, createProductDto);
+    const savedProduct = await this.productRepository.getProduct(id);
+
+    if (!savedProduct) {
+      throw new NotFoundException(`Product Save failed `);
+    }
+
+    return savedProduct;
   }
 
   async createProductOptions(

--- a/src/util/functions/create-product-pagination-form.function.ts
+++ b/src/util/functions/create-product-pagination-form.function.ts
@@ -1,11 +1,11 @@
 import { GetProductListPaginationDto } from 'src/entities/dtos/get-product-list-pagination.dto';
 import { GetProductListResponse } from 'src/interfaces/get-product-list-response.interface';
 import { GetResponse } from 'src/interfaces/get-response.interface';
-import { ProductElement } from 'src/interfaces/product-element.interface';
+import { ProductListElement } from 'src/interfaces/product-list-element.interface';
 import { getTotalPage } from './get-total-page.function';
 
 export function createProductPaginationForm(
-  getResponse: GetResponse<ProductElement>,
+  getResponse: GetResponse<ProductListElement>,
   getProductPagintionDto: GetProductListPaginationDto,
 ): GetProductListResponse {
   const { list, count, take } = getResponse;


### PR DESCRIPTION
## Overview 
아래 API에 대해 레포지토리 로직을 분리중 입니다!

- Category API
- Company API
- Seller API

## Implementations

- **Category API |  Company API**
단순한 Get API밖에 없었기 때문에 DTO를 정의와 코드 분리외에 큰 변화는 없습니다.
테스트는 아직 하지 못했습니다.

- **Seller API**
전부 Post API 요청이었기에 DTO 정의외에도 서비스로직에 변화가 있습니다.

기존에는 무조건 `save`가 된다고 가정 저장이 안되었는지 확인조차 하지않는 코드였고,

같은 Post요청인데도 반환값이 없는경우(...), 
엔티티를 반환하는 경우, 
정의된 객체를 반환하는 경우로 제각각이었습니다. 

일단 모두 수정하였지만 기존의 테스트 코드가 작동되지 않는 상태입니다.


반환되는 객체가 달라져 프로퍼티 참조를 못하고 있는 것을 확인하였으나,
테스트 코드 자체가 컨트롤러, 서비스 로직을 테스트 하는것과는 거리가 멀다고 판단해 

새로운 테스트 코드를 작성할 예정입니다.
이후 PR 드리겠습니다.
