### PR TITLE
주문 내역 도메인에 대한 참조/역참조 관계 수정

### DIFF
--- a/src/entities/buyer.entity.ts
+++ b/src/entities/buyer.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToMany, Unique } from 'typeorm';
+import { Column, Entity, OneToMany } from 'typeorm';
 import { BoardEntity } from './board.entity';
 import { CartEntity } from './cart.entity';
 import { CommonEntity } from './common/common.entity';

--- a/src/entities/order-product-bundle.entity.ts
+++ b/src/entities/order-product-bundle.entity.ts
@@ -1,8 +1,6 @@
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { feeStandard } from 'src/types/enums/fee-standard.enum';
 import { CommonEntity } from './common/common.entity';
-import { OrderProductOptionEntity } from './order-product-option.entity';
-import { OrderProductRequiredOptionEntity } from './order-product-riquired-option.entity';
 import { OrderProductEntity } from './order-product.entity';
 import { OrderEntity } from './order.entity';
 
@@ -24,11 +22,9 @@ export class OrderProductBundleEntity extends CommonEntity {
   @OneToMany(() => OrderProductEntity, (op) => op.orderProductBundle)
   orderProducts!: OrderProductEntity[];
 
-  @OneToMany(() => OrderProductRequiredOptionEntity, (opro) => opro.orderProductBundle)
-  orderProductRequiredOptions!: OrderProductRequiredOptionEntity[];
-
-  @OneToMany(() => OrderProductOptionEntity, (opo) => opo.orderProductBundle)
-  orderProductOptions!: OrderProductOptionEntity[];
+  @ManyToOne(() => OrderEntity, (o) => o.orderProductBundles)
+  @JoinColumn({ referencedColumnName: 'id' })
+  order!: OrderEntity;
 
   @ManyToOne(() => OrderEntity, (o) => o.orderProductBundles)
   @JoinColumn({ referencedColumnName: 'id' })

--- a/src/entities/order-product-input-option.entity.ts
+++ b/src/entities/order-product-input-option.entity.ts
@@ -1,6 +1,6 @@
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { CommonEntity } from './common/common.entity';
-import { OrderProductRequiredOptionEntity } from './order-product-riquired-option.entity';
+import { OrderProductRequiredOptionEntity } from './order-product-required-option.entity';
 
 @Entity({ name: 'order_product_input_option' })
 export class OrderProductInputOptionEntity extends CommonEntity {

--- a/src/entities/order-product-option.entity.ts
+++ b/src/entities/order-product-option.entity.ts
@@ -1,11 +1,11 @@
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { CommonEntity } from './common/common.entity';
-import { OrderProductBundleEntity } from './order-product-bundle.entity';
+import { OrderProductEntity } from './order-product.entity';
 
 @Entity({ name: 'order_product_option' })
 export class OrderProductOptionEntity extends CommonEntity {
   @Column()
-  OrderProductOptionId!: number;
+  orderProductId!: number;
 
   @Column({ type: 'varchar', length: 128 })
   name!: string;
@@ -16,7 +16,7 @@ export class OrderProductOptionEntity extends CommonEntity {
   @Column({ type: 'int' })
   count!: number;
 
-  @ManyToOne(() => OrderProductBundleEntity, (opb) => opb.orderProductOptions)
+  @ManyToOne(() => OrderProductEntity, (opb) => opb.orderProductOptions)
   @JoinColumn({ referencedColumnName: 'id' })
-  orderProductBundle!: OrderProductBundleEntity;
+  orderProduct!: OrderProductEntity;
 }

--- a/src/entities/order-product-required-option.entity.ts
+++ b/src/entities/order-product-required-option.entity.ts
@@ -1,12 +1,12 @@
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { CommonEntity } from './common/common.entity';
-import { OrderProductBundleEntity } from './order-product-bundle.entity';
 import { OrderProductInputOptionEntity } from './order-product-input-option.entity';
+import { OrderProductEntity } from './order-product.entity';
 
 @Entity({ name: 'order_product_required_option' })
 export class OrderProductRequiredOptionEntity extends CommonEntity {
   @Column()
-  OrderProductBundleId!: number;
+  orderProductId!: number;
 
   @Column({ type: 'varchar', length: 128 })
   name!: string;
@@ -17,9 +17,9 @@ export class OrderProductRequiredOptionEntity extends CommonEntity {
   @Column({ type: 'int' })
   count!: number;
 
-  @ManyToOne(() => OrderProductBundleEntity, (opb) => opb.orderProductRequiredOptions)
+  @ManyToOne(() => OrderProductEntity, (opb) => opb.orderProductRequiredOptions)
   @JoinColumn({ referencedColumnName: 'id' })
-  orderProductBundle!: OrderProductBundleEntity;
+  orderProduct!: OrderProductEntity;
 
   @OneToMany(() => OrderProductInputOptionEntity, (opio) => opio.orderProductRequiredOption)
   orderProductInputOptions!: OrderProductInputOptionEntity[];

--- a/src/entities/order-product.entity.ts
+++ b/src/entities/order-product.entity.ts
@@ -1,13 +1,15 @@
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { CartEntity } from './cart.entity';
 import { CommonEntity } from './common/common.entity';
 import { OrderProductBundleEntity } from './order-product-bundle.entity';
+import { OrderProductOptionEntity } from './order-product-option.entity';
+import { OrderProductRequiredOptionEntity } from './order-product-required-option.entity';
 import { ProductEntity } from './product.entity';
 
 @Entity({ name: 'order_product' })
 export class OrderProductEntity extends CommonEntity {
   @Column()
-  orderProductId!: number;
+  orderProductBundleId!: number;
 
   @Column()
   cartId!: number;
@@ -26,4 +28,10 @@ export class OrderProductEntity extends CommonEntity {
   @ManyToOne(() => ProductEntity, (p) => p.orderProducts)
   @JoinColumn({ referencedColumnName: 'id' })
   product!: ProductEntity;
+
+  @OneToMany(() => OrderProductRequiredOptionEntity, (opro) => opro.orderProduct)
+  orderProductRequiredOptions!: OrderProductRequiredOptionEntity[];
+
+  @OneToMany(() => OrderProductOptionEntity, (opo) => opo.orderProduct)
+  orderProductOptions!: OrderProductOptionEntity[];
 }


### PR DESCRIPTION
## Background(배경지식)
- 제가 더 꼼꼼히 봐야 했던 부분인데 제 탓에 누락된 거 같습니다.
- 포트폴리오 정리 중이신 거 같은데, 열심히 하는 모습이 항상 보기 좋습니다. :)

## Implementations(보충설명)
- 판매자와 구매자 도메인 구조와 마찬가지로 주문서도 번들이 가운데 껴있는 구조입니다.
- 작성하신 내역을 보면 인지하신 사실인 것 같은데 아직 주문 내역까지 가지 못해 수정이 미뤄진 거 같아서 대신 PR을 날려봅니다.
- 한 번 달라진 부분을 체크하고 코멘트 남겨주시고 직접 merge 해주시면 될 거 같아요 ( Entity sync는 제가 체크했습니다! )

## Screenshots (Optional)

<!-- You can substitude screenshots with vercel preview -->

## Focus On (Optional)
<!-- 특이점, 중점적으로 봐줬으면 하는 부분이 있다면 말씀해주세요 -->
- 미처 제가 못본 부분이 있을지 모르니 함께 보시죠!


## Other (Optional)
<!-- 질문, 토의점, 그 외 하고 싶은 말 -->

## References (Optional)
<!-- 참고한 자료가 있다면 같이 링크를 주시면 감사하겠습니다 -->
