### PR TITLE
장바구니 상품 옵션 수량 변경 API를 추가했습니다!

### DIFF
--- a/src/controllers/cart.controller.ts
+++ b/src/controllers/cart.controller.ts
@@ -1,10 +1,11 @@
-import { Body, Controller, Get, HttpCode, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, Patch, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { BuyerJwtAuthGuard } from 'src/auth/guards/buyer-jwt.guard';
 import { UserId } from 'src/decorators/user-id.decorator';
 import { CartGroupByProductBundleDto } from 'src/entities/dtos/cart-group-by-product-bundle.dto';
 import { CartDto } from 'src/entities/dtos/cart.dto';
 import { CreateCartDto } from 'src/entities/dtos/create-cart.dto';
+import { UpdateCartOptionCountDto } from 'src/entities/dtos/update-cart-option-count.dto';
 import { UpdateCartDto } from 'src/entities/dtos/update-cart.dto';
 import { CartService } from 'src/services/cart.service';
 
@@ -38,5 +39,18 @@ export class CartController {
   }> {
     const carts = await this.cartService.readCarts(buyerId);
     return { data: carts };
+  }
+
+  @Patch()
+  @ApiOperation({
+    summary: '장바구니 옵션 수량 변경 API',
+    description: '모든 사용자는 담은 상품 옵션의 수량을 변경 할 수 있다.',
+  })
+  async updateCartsOptionCount(
+    @UserId() buyerId: number,
+    @Body() updateCartOptionCountDto: UpdateCartOptionCountDto,
+  ): Promise<any> {
+    const result = await this.cartService.updateCartsOptionCount(buyerId, updateCartOptionCountDto);
+    return { data: result };
   }
 }

--- a/src/controllers/cart.controller.ts
+++ b/src/controllers/cart.controller.ts
@@ -49,7 +49,7 @@ export class CartController {
   async updateCartsOptionCount(
     @UserId() buyerId: number,
     @Body() updateCartOptionCountDto: UpdateCartOptionCountDto,
-  ): Promise<any> {
+  ): Promise<{ data: number }> {
     const result = await this.cartService.updateCartsOptionCount(buyerId, updateCartOptionCountDto);
     return { data: result };
   }

--- a/src/entities/dtos/cart-product-detail.dto.ts
+++ b/src/entities/dtos/cart-product-detail.dto.ts
@@ -1,8 +1,8 @@
+import { CartOptionEntity } from '../cart-option.entity';
+import { CartRequiredOptionEntity } from '../cart-required-option.entity';
 import { CartEntity } from '../cart.entity';
-import { CartOptionDto } from './cart-option.dto';
-import { CartRequiredOptionDto } from './cart-required-option.dto';
-import { ProductOptionDto } from './product-option.dto';
-import { ProductRequiredOptionDto } from './product-required-option.dto';
+import { ProductOptionEntity } from '../product-option.entity';
+import { ProductRequiredOptionEntity } from '../product-required-option.entity';
 import { ProductDto } from './product.dto';
 
 export class CartProductDetailDto {
@@ -10,8 +10,10 @@ export class CartProductDetailDto {
   buyerId!: number;
   productId!: number;
   product: ProductDto;
-  cartRequiredOptions!: (CartRequiredOptionDto & ProductRequiredOptionDto)[];
-  cartOptions!: (CartOptionDto & ProductOptionDto)[];
+  cartRequiredOptions!: (Pick<CartRequiredOptionEntity, 'id' | 'cartId' | 'productRequiredOptionId' | 'count'> &
+    Pick<ProductRequiredOptionEntity, 'productId' | 'price' | 'name' | 'isSale'>)[];
+  cartOptions!: (Pick<CartOptionEntity, 'id' | 'cartId' | 'productOptionId' | 'count'> &
+    Pick<ProductOptionEntity, 'productId' | 'price' | 'name' | 'isSale'>)[];
 
   constructor(cart: CartEntity) {
     this.id = cart.id;
@@ -19,10 +21,28 @@ export class CartProductDetailDto {
     this.productId = cart.productId;
     this.product = new ProductDto(cart.product);
     this.cartRequiredOptions = cart.cartRequiredOptions.map((ro) => {
-      return { ...new CartRequiredOptionDto(ro), ...new ProductRequiredOptionDto(ro.productRequiredOption) };
+      return {
+        id: ro.id,
+        cartId: ro.cartId,
+        productId: ro.productRequiredOption.productId,
+        productRequiredOptionId: ro.productRequiredOptionId,
+        count: ro.count,
+        price: ro.productRequiredOption.price,
+        name: ro.productRequiredOption.name,
+        isSale: ro.productRequiredOption.isSale,
+      };
     });
     this.cartOptions = cart.cartOptions.map((o) => {
-      return { ...new CartOptionDto(o), ...new ProductOptionDto(o.productOption) };
+      return {
+        id: o.id,
+        cartId: o.cartId,
+        productId: o.productOption.productId,
+        productOptionId: o.productOptionId,
+        count: o.count,
+        price: o.productOption.price,
+        name: o.productOption.name,
+        isSale: o.productOption.isSale,
+      };
     });
   }
 }

--- a/src/entities/dtos/cart-product-detail.dto.ts
+++ b/src/entities/dtos/cart-product-detail.dto.ts
@@ -1,19 +1,18 @@
-import { CartOptionEntity } from '../cart-option.entity';
-import { CartRequiredOptionEntity } from '../cart-required-option.entity';
+import { Omit } from 'src/types/omit-type';
 import { CartEntity } from '../cart.entity';
-import { ProductOptionEntity } from '../product-option.entity';
-import { ProductRequiredOptionEntity } from '../product-required-option.entity';
+import { CartOptionDto } from './cart-option.dto';
+import { CartRequiredOptionDto } from './cart-required-option.dto';
+import { ProductOptionDto } from './product-option.dto';
+import { ProductRequiredOptionDto } from './product-required-option.dto';
 import { ProductDto } from './product.dto';
 
 export class CartProductDetailDto {
   id!: number;
   buyerId!: number;
   productId!: number;
-  product: ProductDto;
-  cartRequiredOptions!: (Pick<CartRequiredOptionEntity, 'id' | 'cartId' | 'productRequiredOptionId' | 'count'> &
-    Pick<ProductRequiredOptionEntity, 'productId' | 'price' | 'name' | 'isSale'>)[];
-  cartOptions!: (Pick<CartOptionEntity, 'id' | 'cartId' | 'productOptionId' | 'count'> &
-    Pick<ProductOptionEntity, 'productId' | 'price' | 'name' | 'isSale'>)[];
+  product!: ProductDto;
+  cartRequiredOptions!: (CartRequiredOptionDto & Omit<ProductRequiredOptionDto, 'id'>)[];
+  cartOptions!: (CartOptionDto & Omit<ProductOptionDto, 'id'>)[];
 
   constructor(cart: CartEntity) {
     this.id = cart.id;

--- a/src/entities/dtos/update-cart-option-count.dto.ts
+++ b/src/entities/dtos/update-cart-option-count.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmptyNumber } from 'src/decorators/is-not-empty-number.decorator';
 import { IsNotEmptyString } from 'src/decorators/is-not-empty-string.decorator';
-import { cartOptionType } from 'src/types/cart-option-type';
+import { CartOptionType } from 'src/types/cart-option-type';
 import { CartEntity } from '../cart.entity';
 import { CartOptionDto } from './cart-option.dto';
 
@@ -15,7 +15,7 @@ export class UpdateCartOptionCountDto
     example: 'requiredOption',
   })
   @IsNotEmptyString()
-  cartOptionType!: cartOptionType;
+  cartOptionType!: CartOptionType;
 
   @ApiProperty({ type: Number, description: '상품 옵션의 id', required: true, example: 1 })
   @IsNotEmptyNumber()
@@ -26,6 +26,6 @@ export class UpdateCartOptionCountDto
   cartId!: number;
 
   @ApiProperty({ type: Number, description: '상품 옵션의 수량', required: true, example: 1 })
-  @IsNotEmptyNumber()
+  @IsNotEmptyNumber('int', { min: 1 })
   count!: number;
 }

--- a/src/entities/dtos/update-cart-option-count.dto.ts
+++ b/src/entities/dtos/update-cart-option-count.dto.ts
@@ -1,20 +1,18 @@
+import { IsEnum } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmptyNumber } from 'src/decorators/is-not-empty-number.decorator';
-import { IsNotEmptyString } from 'src/decorators/is-not-empty-string.decorator';
 import { CartOptionType } from 'src/types/cart-option-type';
-import { CartEntity } from '../cart.entity';
 import { CartOptionDto } from './cart-option.dto';
 
-export class UpdateCartOptionCountDto
-  implements Pick<CartEntity, 'id'>, Pick<CartOptionDto, 'cartId' | 'id' | 'count'>
-{
+export class UpdateCartOptionCountDto implements Pick<CartOptionDto, 'id' | 'cartId' | 'count'> {
   @ApiProperty({
     type: String,
+    enum: ['requiredOption', 'option'],
     description: '옵션의 종류를 입력합니다. (option / requiredOption)',
     required: true,
     example: 'requiredOption',
   })
-  @IsNotEmptyString()
+  @IsEnum(['requiredOption', 'option'])
   cartOptionType!: CartOptionType;
 
   @ApiProperty({ type: Number, description: '상품 옵션의 id', required: true, example: 1 })
@@ -26,6 +24,6 @@ export class UpdateCartOptionCountDto
   cartId!: number;
 
   @ApiProperty({ type: Number, description: '상품 옵션의 수량', required: true, example: 1 })
-  @IsNotEmptyNumber('int', { min: 1 })
+  @IsNotEmptyNumber('int', { min: 1, max: 999 })
   count!: number;
 }

--- a/src/entities/dtos/update-cart-option-count.dto.ts
+++ b/src/entities/dtos/update-cart-option-count.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmptyNumber } from 'src/decorators/is-not-empty-number.decorator';
+import { IsNotEmptyString } from 'src/decorators/is-not-empty-string.decorator';
+import { cartOptionType } from 'src/types/cart-option-type';
+import { CartEntity } from '../cart.entity';
+import { CartOptionDto } from './cart-option.dto';
+
+export class UpdateCartOptionCountDto
+  implements Pick<CartEntity, 'id'>, Pick<CartOptionDto, 'cartId' | 'id' | 'count'>
+{
+  @ApiProperty({
+    type: String,
+    description: '옵션의 종류를 입력합니다. (option / requiredOption)',
+    required: true,
+    example: 'requiredOption',
+  })
+  @IsNotEmptyString()
+  cartOptionType!: cartOptionType;
+
+  @ApiProperty({ type: Number, description: '상품 옵션의 id', required: true, example: 1 })
+  @IsNotEmptyNumber()
+  id!: number;
+
+  @ApiProperty({ type: Number, description: '장바구니의 id', required: true, example: 1 })
+  @IsNotEmptyNumber()
+  cartId!: number;
+
+  @ApiProperty({ type: Number, description: '상품 옵션의 수량', required: true, example: 1 })
+  @IsNotEmptyNumber()
+  count!: number;
+}

--- a/src/exceptions/cart.exception.ts
+++ b/src/exceptions/cart.exception.ts
@@ -6,6 +6,24 @@ export class CartNotFoundException extends HttpException {
   }
 }
 
+export class CartRequiredOptionNotFoundException extends HttpException {
+  constructor() {
+    super(`Can't find Cart Required Option`, HttpStatus.NOT_FOUND);
+  }
+}
+
+export class CartOptionNotFoundException extends HttpException {
+  constructor() {
+    super(`Can't find Cart Option`, HttpStatus.NOT_FOUND);
+  }
+}
+
+export class CartForbiddenException extends HttpException {
+  constructor() {
+    super(`Cart resource is forbidden.`, HttpStatus.FORBIDDEN);
+  }
+}
+
 export class CartIntercnalServerErrorException extends HttpException {
   constructor() {
     super(`Cart update error`, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/repositories/cart-option.repository.ts
+++ b/src/repositories/cart-option.repository.ts
@@ -10,6 +10,11 @@ export class CartOptionRepository extends Repository<CartOptionEntity> {
     return await this.save(entitiesToSave);
   }
 
+  async updateOptionsCount(id: number, count: number): Promise<number | null> {
+    const updateResult = await this.update(id, { count });
+    return updateResult.affected ? id : null;
+  }
+
   async increaseOptionsCount(options: { id: number; count: number }[]): Promise<number[]> {
     const updatedIds: number[] = [];
 

--- a/src/repositories/cart-required-option.repository.ts
+++ b/src/repositories/cart-required-option.repository.ts
@@ -15,7 +15,6 @@ export class CartRequiredOptionRepository extends Repository<CartRequiredOptionE
 
   async updateRequiredOptionsCount(id: number, count: number): Promise<number | null> {
     const updateResult = await this.update(id, { count: count });
-    console.log(updateResult.affected);
     return updateResult.affected ? id : null;
   }
 

--- a/src/repositories/cart-required-option.repository.ts
+++ b/src/repositories/cart-required-option.repository.ts
@@ -13,6 +13,12 @@ export class CartRequiredOptionRepository extends Repository<CartRequiredOptionE
     return await this.save(entitiesToSave);
   }
 
+  async updateRequiredOptionsCount(id: number, count: number): Promise<number | null> {
+    const updateResult = await this.update(id, { count: count });
+    console.log(updateResult.affected);
+    return updateResult.affected ? id : null;
+  }
+
   async increaseRequiredOptionsCount(options: { id: number; count: number }[]): Promise<number[]> {
     const updatedIds: number[] = [];
 

--- a/src/repositories/cart.repository.ts
+++ b/src/repositories/cart.repository.ts
@@ -7,7 +7,18 @@ export class CartRepository extends Repository<CartEntity> {
   async saveCart(buyerId: number, productId: number): Promise<CartEntity> {
     return await this.save({ buyerId, productId });
   }
-  async findCart(buyerId: number, productId: number): Promise<CartEntity | null> {
+
+  async findCartWithOptions(cartId: number): Promise<CartEntity | null> {
+    const cart = await this.createQueryBuilder('cart')
+      .innerJoinAndSelect('cart.cartRequiredOptions', 'cartRequiredOption')
+      .leftJoinAndSelect('cart.cartOptions', 'cartOption')
+      .where('cart.id = :cartId', { cartId })
+      .getOne();
+
+    return cart;
+  }
+
+  async findCartByProductId(buyerId: number, productId: number): Promise<CartEntity | null> {
     const cart = await this.createQueryBuilder('cart')
       .innerJoinAndSelect('cart.cartRequiredOptions', 'cartRequiredOption')
       .leftJoinAndSelect('cart.cartOptions', 'cartOption')
@@ -16,6 +27,7 @@ export class CartRepository extends Repository<CartEntity> {
       .getOne();
     return cart;
   }
+
   async findCartDetail(buyerId: number): Promise<CartEntity[]> {
     const carts = await this.createQueryBuilder('cart')
       .innerJoinAndSelect('cart.cartRequiredOptions', 'cartRequiredOption')

--- a/src/services/cart.service.ts
+++ b/src/services/cart.service.ts
@@ -6,6 +6,7 @@ import { CartDto } from 'src/entities/dtos/cart.dto';
 import { CreateCartOptionDto } from 'src/entities/dtos/create-cart-option.dto';
 import { CreateCartRequiredOptionDto } from 'src/entities/dtos/create-cart-required-option.dto';
 import { CreateCartDto } from 'src/entities/dtos/create-cart.dto';
+import { UpdateCartOptionCountDto } from 'src/entities/dtos/update-cart-option-count.dto';
 import { UpdateCartDto } from 'src/entities/dtos/update-cart.dto';
 import { CartDeliveryTypeNotFoundException, CartIntercnalServerErrorException } from 'src/exceptions/cart.exception';
 import { CartOptionRepository } from 'src/repositories/cart-option.repository';
@@ -271,21 +272,14 @@ export class CartService {
   }
 
   /**
-   * 이미 담긴 장바구니 상품의 수량을 변경한다.
+   * 이미 담긴 장바구니 옵션의 상품의 수량을 변경합니다.
    *
-   * @param userId
-   * @param cartId
-   * @param cartOptionId
-   * @param cartType
-   * @param count
+   * @param buyerId 유저의 아이디
+   * @param updateCartOptionCountDto
+   *
+   * @returns 변경된 결과를 반환합니다.
    */
-  async updateCart(
-    userId: number,
-    cartId: number,
-    cartOptionId: number,
-    cartType: 'option' | 'requiredOption',
-    count: number,
-  ) {}
+  async updateCartsOptionCount(buyerId: number, updateCartOptionCountDto: UpdateCartOptionCountDto): Promise<any> {}
 
   /**
    * 장바구니에서 상품을 지웁니다.

--- a/src/types/cart-option-type.ts
+++ b/src/types/cart-option-type.ts
@@ -1,0 +1,1 @@
+export type cartOptionType = 'requiredOption' | 'option';

--- a/src/types/cart-option-type.ts
+++ b/src/types/cart-option-type.ts
@@ -1,1 +1,1 @@
-export type cartOptionType = 'requiredOption' | 'option';
+export type CartOptionType = 'requiredOption' | 'option';

--- a/src/types/omit-type.ts
+++ b/src/types/omit-type.ts
@@ -1,0 +1,3 @@
+export type Omit<T, K extends keyof T> = {
+  [key in keyof T as key extends K ? never : key]: T[key];
+};


### PR DESCRIPTION
## Overview
장바구니에 담긴 필수옵션(cart_required_option), 옵션(cart_option)의 수량(count)를 update하는 API를 추가했습니다.

업데이트에 성공하면, 성공한 옵션의 id를 반환합니다. 아니라면 에러를 던집니다.


## DTO
- API 요청시 사용되는 `UpdateCartOptionCountDto`를 추가하였습니다.
- 테스트 확인 과정에서 `CartProductDetailDto`의 옵션관련 데이터가 잘못 들어가고 있다는 것을 확인하고 수정했습니다.


## 엔드포인트 및 비지니스 로직 추가
- 컨트롤러와 서비스에 메소드 `updateCartsOptionCount`를 추가하였습니다. 
- API 호출 결과는 `{ data : number }` 입니다.

## 레포지토리 메소드 추가

아래 메소드들을 추가하였습니다.

- findCartWithOptions : 장바구니 id를 받아 담긴 상품과 옵션들을 조회
- updateRequiredOptionsCount : 해당 id를 가진 장바구니 필수 옵션의 수량을 변경
- updateOptionsCount : 해당 id를 가진 장바구니 옵션의 수량을 변경

장바구니 생성시 이미 담겨있는 상품이라면 수량을 더해주는 레포지토리 메소드와 별도로 작동합니다.

## 테스트 코드 추가

테스트가 통과하는 것을 확인했습니다.