### PR TITLE
Company API를 리팩토링 했습니다!

### DIFF
--- a/src/controllers/company.controller.ts
+++ b/src/controllers/company.controller.ts
@@ -2,12 +2,11 @@ import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { SellerJwtAuthGuard } from 'src/auth/guards/seller-jwt.guard';
 import { UserId } from 'src/decorators/user-id.decorator';
-import { CompanyEntity } from 'src/entities/company.entity';
 import { GetCompanyDto } from 'src/entities/dtos/get-company.dto';
+import { PaginationResponseDto } from 'src/entities/dtos/pagination-response.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
-import { PaginationResponseForm } from 'src/interfaces/pagination-response-form.interface';
 import { CompanyService } from 'src/services/company.service';
-import { createResponseForm } from 'src/util/functions/create-response-form.function';
+import { createProductPaginationForm } from 'src/util/functions/create-product-pagination-form.function';
 
 @Controller('company')
 @ApiTags('Company API')
@@ -17,14 +16,10 @@ export class CompanyController {
 
   @Get()
   async getCompany(
-    /**
-     * @todo
-     * sellerId 추후 사용 예정
-     */
-    // @UserId() sellerId: number,
+    @UserId() sellerId: number,
     @Query() paginationDto: PaginationDto,
-  ): Promise<PaginationResponseForm<GetCompanyDto>> {
-    const response = await this.companyService.getCompany(paginationDto);
-    return createResponseForm(response, paginationDto);
+  ): Promise<PaginationResponseDto<GetCompanyDto>> {
+    const response = await this.companyService.getCompany(sellerId, paginationDto);
+    return createProductPaginationForm(response);
   }
 }

--- a/src/controllers/company.controller.ts
+++ b/src/controllers/company.controller.ts
@@ -1,12 +1,12 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { SellerJwtAuthGuard } from 'src/auth/guards/seller-jwt.guard';
 import { UserId } from 'src/decorators/user-id.decorator';
 import { GetCompanyDto } from 'src/entities/dtos/get-company.dto';
 import { PaginationResponseDto } from 'src/entities/dtos/pagination-response.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
 import { CompanyService } from 'src/services/company.service';
-import { createProductPaginationForm } from 'src/util/functions/create-product-pagination-form.function';
+import { createPaginationResponseDto } from 'src/util/functions/create-pagination-response-dto.function';
 
 @Controller('company')
 @ApiTags('Company API')
@@ -15,11 +15,12 @@ export class CompanyController {
   constructor(private readonly companyService: CompanyService) {}
 
   @Get()
+  @ApiOperation({ summary: '회사 조회 API', description: '등록된 회사를 페이지 네이션으로 확인할 수 있다.' })
   async getCompany(
     @UserId() sellerId: number,
     @Query() paginationDto: PaginationDto,
   ): Promise<PaginationResponseDto<GetCompanyDto>> {
     const response = await this.companyService.getCompany(sellerId, paginationDto);
-    return createProductPaginationForm(response);
+    return createPaginationResponseDto(response);
   }
 }

--- a/src/entities/dtos/get-company.dto.ts
+++ b/src/entities/dtos/get-company.dto.ts
@@ -1,4 +1,3 @@
-import { PickType } from '@nestjs/swagger';
-import { CompanyEntity } from '../company.entity';
+import { Company } from '@prisma/client';
 
-export class GetCompanyDto extends PickType(CompanyEntity, ['id', 'name']) {}
+export interface GetCompanyDto extends Pick<Company, 'id' | 'name'> {}

--- a/src/interfaces/get-response.interface.ts
+++ b/src/interfaces/get-response.interface.ts
@@ -1,5 +1,16 @@
-export interface GetResponse<T> {
+/**
+ * @todo 삭제
+ */
+
+export interface _GetResponse<T> {
   list: T[];
+  count: number;
+  take: number;
+}
+
+export interface GetResponse<T> {
+  data: T[];
+  skip: number;
   count: number;
   take: number;
 }

--- a/src/modules/company.module.ts
+++ b/src/modules/company.module.ts
@@ -3,9 +3,10 @@ import { CustomTypeOrmModule } from 'src/configs/custom-typeorm.module';
 import { CompanyController } from 'src/controllers/company.controller';
 import { CompanyRepository } from 'src/repositories/company.repository';
 import { CompanyService } from 'src/services/company.service';
+import { PrismaModule } from './prisma.module';
 
 @Module({
-  imports: [CustomTypeOrmModule.forCustomRepository([CompanyRepository])],
+  imports: [PrismaModule, CustomTypeOrmModule.forCustomRepository([CompanyRepository])],
   controllers: [CompanyController],
   providers: [CompanyService],
 })

--- a/src/services/company.service.ts
+++ b/src/services/company.service.ts
@@ -1,21 +1,33 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
 import { GetCompanyDto } from 'src/entities/dtos/get-company.dto';
 import { PaginationDto } from 'src/entities/dtos/pagination.dto';
+import { SellerNotfoundException } from 'src/exceptions/auth.exception';
 import { GetResponse } from 'src/interfaces/get-response.interface';
-import { CompanyRepository } from 'src/repositories/company.repository';
 import { getOffset } from 'src/util/functions/get-offset.function';
+import { PrismaService } from './prisma.service';
 
 @Injectable()
 export class CompanyService {
-  constructor(
-    @InjectRepository(CompanyRepository)
-    private readonly companyRepository: CompanyRepository,
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
-  async getCompany(paginationDto: PaginationDto): Promise<GetResponse<GetCompanyDto>> {
+  async getCompany(sellerId: number, paginationDto: PaginationDto): Promise<GetResponse<GetCompanyDto>> {
+    const seller = await this.prisma.seller.findUnique({ select: { id: true }, where: { id: sellerId } });
+
+    if (!seller) {
+      throw new SellerNotfoundException();
+    }
+
     const { skip, take } = getOffset(paginationDto);
-    const [list, count] = await this.companyRepository.getCompany(skip, take);
-    return { list, count, take };
+
+    const data = await this.prisma.company.findMany({
+      select: { id: true, name: true },
+      skip,
+      take,
+      orderBy: [{ name: 'asc' }, { id: 'asc' }],
+    });
+
+    const count = await this.prisma.company.count();
+
+    return { data, skip, count, take };
   }
 }

--- a/src/util/functions/create-pagination-response-dto.function.ts
+++ b/src/util/functions/create-pagination-response-dto.function.ts
@@ -1,0 +1,15 @@
+import { PaginationResponseDto } from 'src/entities/dtos/pagination-response.dto';
+import { GetResponse } from 'src/interfaces/get-response.interface';
+import { getTotalPage } from './get-total-page.function';
+
+export function createPaginationResponseDto<T>(response: GetResponse<T>): PaginationResponseDto<T> {
+  return {
+    data: response.data,
+    meta: {
+      page: response.skip / response.take + 1,
+      take: response.take,
+      totalCount: response.take,
+      totalPage: getTotalPage(response.count, response.take),
+    },
+  };
+}

--- a/src/util/functions/create-product-pagination-form.function.ts
+++ b/src/util/functions/create-product-pagination-form.function.ts
@@ -1,21 +1,15 @@
-import { GetProductListPaginationDto } from 'src/entities/dtos/get-product-list-pagination.dto';
-import { GetProductListResponse } from 'src/interfaces/get-product-list-response.interface';
+import { PaginationResponseDto } from 'src/entities/dtos/pagination-response.dto';
 import { GetResponse } from 'src/interfaces/get-response.interface';
-import { ProductListElement } from 'src/interfaces/product-list-element.interface';
 import { getTotalPage } from './get-total-page.function';
 
-export function createProductPaginationForm(
-  getResponse: GetResponse<ProductListElement>,
-  getProductPagintionDto: GetProductListPaginationDto,
-): GetProductListResponse {
-  const { list, count, take } = getResponse;
-  const totalPage = getTotalPage(count, take);
-
-  const lastProductId = list.at(list.length - 1)?.id;
-  const result: GetProductListResponse = {
-    data: { list, totalPage, lastProductId: lastProductId ?? null },
-    meta: getProductPagintionDto,
+export function createProductPaginationForm<T>(response: GetResponse<T>): PaginationResponseDto<T> {
+  return {
+    data: response.data,
+    meta: {
+      page: response.skip / response.take + 1,
+      take: response.take,
+      totalCount: response.take,
+      totalPage: getTotalPage(response.count, response.take),
+    },
   };
-
-  return result;
 }


### PR DESCRIPTION
# Overview
Prisma에 익숙해지기 위해 기존의 API를 리팩토링 하는 중입니다.

Company API에 프리즈마를 적용합니다.

## Implementations(보충설명)

- TypeORM의 레포지토리 의존성을 제거하고, 프리즈마를 사용하도록 변경했습니다.
- DTO의 타입을 프리즈마의 모델에서 가져오도록 변경합니다.
- 테스트를 재작성하였고 통과하는 것을 확인했습니다.

### DTO
클래스로 작성되었던 DTO를 인터페이스로 변경하고 있습니다.

- 프리즈마로 ORM을 변경하며 Select한 컬럼의 타입이 추론 가능해지면서, 잘못된 데이터 매핑 가능성이 적어졌습니다.
- 클래스 생성자를 통해 진행하던 매핑 과정을 제거하고, 서비스 로직에서 처리하거나 별도의 함수로 처리하려고 합니다.
- 이를 반영하기 위해 페이지네이션 응답 DTO를 만드는 함수 `createPaginationResponseDto`을 재작성 하였습니다. [(관련커밋)](https://github.com/rimo030/nestjs-e-commerce-frame/pull/97/commits/407542b09026a6eed80ec04ec677446fd0c2c94b)