### PR TITLE
상품 필수/선택 옵션 조회 API를 추가했습니다!

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -8,11 +8,9 @@ import { CreateBuyerDto } from '../dtos/create-buyer.dto';
 import { CreateSellerDto } from '../dtos/create-seller.dto';
 import {
   AuthForbiddenException,
-  BuyerEmailNotfoundException,
-  BuyerNotfoundException,
   BuyerUnauthrizedException,
-  SellerEmailNotfoundException,
-  SellerNotfoundException,
+  SellerEmailNotFoundException,
+  SellerNotFoundException,
   SellerUnauthrizedException,
 } from '../exceptions/auth.exception';
 
@@ -93,9 +91,9 @@ export class AuthService {
       if (isRightPassword) {
         return { id: buyer.id };
       }
-      throw new BuyerNotfoundException();
+      throw new SellerNotFoundException();
     }
-    throw new BuyerNotfoundException();
+    throw new SellerNotFoundException();
   }
 
   /**
@@ -115,9 +113,9 @@ export class AuthService {
       if (isRightPassword) {
         return { id: seller.id };
       }
-      throw new SellerNotfoundException();
+      throw new SellerNotFoundException();
     }
-    throw new SellerNotfoundException();
+    throw new SellerNotFoundException();
   }
 
   /**
@@ -155,7 +153,7 @@ export class AuthService {
     });
 
     if (!buyerId) {
-      throw new BuyerEmailNotfoundException();
+      throw new SellerEmailNotFoundException();
     }
     return buyerId;
   }
@@ -171,7 +169,7 @@ export class AuthService {
     });
 
     if (!sellerId) {
-      throw new SellerEmailNotfoundException();
+      throw new SellerEmailNotFoundException();
     }
     return sellerId;
   }

--- a/src/controllers/seller.controller.ts
+++ b/src/controllers/seller.controller.ts
@@ -6,6 +6,7 @@ import { CreateProductBundleDto } from 'src/dtos/create-product-bundle.dto';
 import { CreateProductOptionsDto } from 'src/dtos/create-product-options.dto';
 import { CreateProductDto } from 'src/dtos/create-product.dto';
 import { GetPaginationDto } from 'src/dtos/get-pagination.dto';
+import { GetProductOptionsPaginationDto } from 'src/dtos/get-product-option-pagination.dto';
 import { GetProductPaginationDto } from 'src/dtos/get-product-pagination.dto';
 import { IsRequireOptionDto } from 'src/dtos/is-require-options.dto';
 import { PaginationDto } from 'src/dtos/pagination.dto';
@@ -73,6 +74,26 @@ export class SellerController {
   }> {
     const product = await this.sellerservice.createProduct(sellerId, createProductDto);
     return { data: product };
+  }
+
+  @Get('/product/:productId/options')
+  @ApiOperation({
+    summary: '상품 옵션 조회 API',
+    description: 'seller는 등록한 상품 필수/선택 옵션을 페이지네이션으로 조회할 수 있다.',
+  })
+  async getProductOptions(
+    @UserId() sellerId: number,
+    @Param('productId', ParseIntPipe) productId: number,
+    @Query() isRequireOptionDto: IsRequireOptionDto,
+    @Query() getProductOptionsPaginationDto: GetProductOptionsPaginationDto,
+  ): Promise<PaginationDto<ProductRequiredOptionDto | ProductOptionDto>> {
+    const paginationResponse = await this.sellerservice.getProductOptions(
+      sellerId,
+      productId,
+      isRequireOptionDto,
+      getProductOptionsPaginationDto,
+    );
+    return createPaginationResponseDto(paginationResponse);
   }
 
   @HttpCode(201)

--- a/src/dtos/get-product-option-pagination.dto.ts
+++ b/src/dtos/get-product-option-pagination.dto.ts
@@ -1,0 +1,8 @@
+import { IntersectionType, PartialType } from '@nestjs/swagger';
+import { CreateProductOptionsDto } from './create-product-options.dto';
+import { GetPaginationDto } from './get-pagination.dto';
+
+export class GetProductOptionsPaginationDto extends IntersectionType(
+  PartialType(CreateProductOptionsDto),
+  GetPaginationDto,
+) {}

--- a/src/dtos/get-product-option-pagination.dto.ts
+++ b/src/dtos/get-product-option-pagination.dto.ts
@@ -1,8 +1,20 @@
-import { IntersectionType, PartialType } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import { ApiProperty, IntersectionType, PartialType } from '@nestjs/swagger';
+import { order } from 'src/types/order-by.type';
 import { CreateProductOptionsDto } from './create-product-options.dto';
 import { GetPaginationDto } from './get-pagination.dto';
 
 export class GetProductOptionsPaginationDto extends IntersectionType(
   PartialType(CreateProductOptionsDto),
   GetPaginationDto,
-) {}
+) {
+  @ApiProperty({
+    type: 'enum',
+    enum: ['asc', 'desc'],
+    description: '가격 정렬 조건',
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'])
+  priceOrder?: order;
+}

--- a/src/exceptions/auth.exception.ts
+++ b/src/exceptions/auth.exception.ts
@@ -15,13 +15,13 @@ export class BuyerUnauthrizedException extends HttpException {
   }
 }
 
-export class BuyerNotfoundException extends HttpException {
+export class BuyerNotFoundException extends HttpException {
   constructor() {
     super('please double-check your email and password.', HttpStatus.NOT_FOUND);
   }
 }
 
-export class BuyerEmailNotfoundException extends HttpException {
+export class BuyerEmailNotFoundException extends HttpException {
   constructor() {
     super(`Can't find buyer email`, HttpStatus.NOT_FOUND);
   }
@@ -36,13 +36,13 @@ export class SellerUnauthrizedException extends HttpException {
   }
 }
 
-export class SellerNotfoundException extends HttpException {
+export class SellerNotFoundException extends HttpException {
   constructor() {
     super('please double-check your email and password.', HttpStatus.NOT_FOUND);
   }
 }
 
-export class SellerEmailNotfoundException extends HttpException {
+export class SellerEmailNotFoundException extends HttpException {
   constructor() {
     super(`Can't find seller email`, HttpStatus.NOT_FOUND);
   }

--- a/src/exceptions/product.exception.ts
+++ b/src/exceptions/product.exception.ts
@@ -2,7 +2,7 @@ import { HttpException, HttpStatus } from '@nestjs/common';
 
 export class ProductBundleNotFoundException extends HttpException {
   constructor() {
-    super(`Can't find product`, HttpStatus.NOT_FOUND);
+    super(`Can't find product Bundle`, HttpStatus.NOT_FOUND);
   }
 }
 

--- a/src/exceptions/seller.exception.ts
+++ b/src/exceptions/seller.exception.ts
@@ -1,5 +1,11 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 
+export class SellerNotfoundException extends HttpException {
+  constructor() {
+    super(`Can't find seller`, HttpStatus.NOT_FOUND);
+  }
+}
+
 export class ProductBundleNotFoundException extends HttpException {
   constructor() {
     super(`Can't find product Budle`, HttpStatus.NOT_FOUND);

--- a/src/exceptions/seller.exception.ts
+++ b/src/exceptions/seller.exception.ts
@@ -1,6 +1,6 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 
-export class SellerNotfoundException extends HttpException {
+export class SellerNotFoundException extends HttpException {
   constructor() {
     super(`Can't find seller`, HttpStatus.NOT_FOUND);
   }
@@ -8,7 +8,7 @@ export class SellerNotfoundException extends HttpException {
 
 export class ProductBundleNotFoundException extends HttpException {
   constructor() {
-    super(`Can't find product Budle`, HttpStatus.NOT_FOUND);
+    super(`Can't find product Bundle`, HttpStatus.NOT_FOUND);
   }
 }
 

--- a/src/exceptions/seller.exception.ts
+++ b/src/exceptions/seller.exception.ts
@@ -1,5 +1,11 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 
+export class ProductBundleNotFoundException extends HttpException {
+  constructor() {
+    super(`Can't find product Budle`, HttpStatus.NOT_FOUND);
+  }
+}
+
 export class ProductNotFoundException extends HttpException {
   constructor() {
     super(`Can't find product`, HttpStatus.NOT_FOUND);

--- a/src/services/company.service.ts
+++ b/src/services/company.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { CompanyDto } from 'src/dtos/company.dto';
 import { GetCompanyPaginationDto } from 'src/dtos/get-company-pagination.dto';
-import { SellerNotfoundException } from 'src/exceptions/auth.exception';
+import { SellerNotFoundException } from 'src/exceptions/auth.exception';
 import { PaginationResponse } from 'src/interfaces/pagination-response.interface';
 import { getOffset } from 'src/util/functions/pagination-util.function';
 import { PrismaService } from './prisma.service';
@@ -21,7 +21,7 @@ export class CompanyService {
       where: { id: sellerId },
     });
     if (!seller) {
-      throw new SellerNotfoundException();
+      throw new SellerNotFoundException();
     }
 
     const category = await this.prisma.company.create({
@@ -46,7 +46,7 @@ export class CompanyService {
       where: { id: sellerId },
     });
     if (!seller) {
-      throw new SellerNotfoundException();
+      throw new SellerNotFoundException();
     }
 
     const savedCompanies = await this.prisma.$transaction(
@@ -73,7 +73,7 @@ export class CompanyService {
     const { search, page, limit } = getCompanyPaginationDto;
     const seller = await this.prisma.seller.findUnique({ select: { id: true }, where: { id: sellerId } });
     if (!seller) {
-      throw new SellerNotfoundException();
+      throw new SellerNotFoundException();
     }
 
     const { skip, take } = getOffset({ page, limit });

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -11,11 +11,11 @@ import { ProductBundleDto } from 'src/dtos/product-bundle.dto';
 import { ProductOptionDto } from 'src/dtos/product-option.dto';
 import { ProductRequiredOptionDto } from 'src/dtos/product-required-option.dto';
 import { ProductDto } from 'src/dtos/product.dto';
-import { SellerNotfoundException } from 'src/exceptions/auth.exception';
 import {
   ProductNotFoundException,
   ProductUnauthrizedException,
   ProductBundleNotFoundException,
+  SellerNotfoundException,
 } from 'src/exceptions/seller.exception';
 import { PaginationResponse } from 'src/interfaces/pagination-response.interface';
 import { getOffset } from 'src/util/functions/pagination-util.function';
@@ -285,7 +285,7 @@ export class SellerService {
       throw new ProductNotFoundException();
     }
 
-    const { name, price, isSale, page, limit } = getProductOptionsPaginationDto;
+    const { name, price, priceOrder, isSale, page, limit } = getProductOptionsPaginationDto;
     const { skip, take } = getOffset({ page, limit });
 
     const productOptionsWhereInput: Prisma.ProductRequiredOptionWhereInput & Prisma.ProductOptionWhereInput = {
@@ -305,9 +305,7 @@ export class SellerService {
             price: true,
             isSale: true,
           },
-          orderBy: {
-            id: 'desc',
-          },
+          orderBy: [{ ...(priceOrder && { price: priceOrder }) }],
           where: productOptionsWhereInput,
           skip,
           take,
@@ -328,9 +326,7 @@ export class SellerService {
             price: true,
             isSale: true,
           },
-          orderBy: {
-            id: 'desc',
-          },
+          orderBy: [{ ...(priceOrder && { price: priceOrder }) }],
           where: productOptionsWhereInput,
           skip,
           take,

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -4,6 +4,7 @@ import { CreateProductBundleDto } from 'src/dtos/create-product-bundle.dto';
 import { CreateProductOptionsDto } from 'src/dtos/create-product-options.dto';
 import { CreateProductDto } from 'src/dtos/create-product.dto';
 import { GetPaginationDto } from 'src/dtos/get-pagination.dto';
+import { GetProductOptionsPaginationDto } from 'src/dtos/get-product-option-pagination.dto';
 import { GetProductPaginationDto } from 'src/dtos/get-product-pagination.dto';
 import { IsRequireOptionDto } from 'src/dtos/is-require-options.dto';
 import { ProductBundleDto } from 'src/dtos/product-bundle.dto';
@@ -254,5 +255,22 @@ export class SellerService {
     ]);
 
     return { data, count, skip, take };
+  }
+
+  /**
+   *등록한 상품 필수/선택옵션을 페이지네이션으로 조회합니다.
+
+   * @param sellerId 조회할 판매자의 아이디 입니다.
+   * @param productId 옵션을 조회하려는 상품의 아이디 입니다.
+   * @param isRequireOptionDto 상품 필수 옵션의 여부 입니다. fasle라면 상품 선택 옵션이 조회되어야 합니다.
+   * @param getProductOptionsPaginationDto 상품 옵션 검색 및 페이지네이션 요청 객체 입니다.
+   */
+  async getProductOptions(
+    sellerId: number,
+    productId: number,
+    isRequireOptionDto: IsRequireOptionDto,
+    getProductOptionsPaginationDto: GetProductOptionsPaginationDto,
+  ): Promise<PaginationResponse<ProductRequiredOptionDto | ProductOptionDto>> {
+    return 1 as any;
   }
 }

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -15,7 +15,7 @@ import {
   ProductNotFoundException,
   ProductUnauthrizedException,
   ProductBundleNotFoundException,
-  SellerNotfoundException,
+  SellerNotFoundException,
 } from 'src/exceptions/seller.exception';
 import { PaginationResponse } from 'src/interfaces/pagination-response.interface';
 import { getOffset } from 'src/util/functions/pagination-util.function';
@@ -32,7 +32,7 @@ export class SellerService {
   async isSeller(sellerId: number): Promise<void> {
     const seller = await this.prisma.seller.findUnique({ select: { id: true }, where: { id: sellerId } });
     if (!seller) {
-      throw new SellerNotfoundException();
+      throw new SellerNotFoundException();
     }
   }
 

--- a/src/test/unit/seller.spec.ts
+++ b/src/test/unit/seller.spec.ts
@@ -312,8 +312,48 @@ describe('Seller Controller', () => {
     });
   });
 
-  describe('seller는 등록한 상품 옵션을 조회할 수 있다.', () => {
-    it.todo('seller는 등록된 상품 옵션을 조회할 수 있다.');
+  describe('seller는 등록한 필수 상품 옵션을 조회할 수 있다.', () => {
+    it.skip('seller는 등록된 상품 필수 옵션을 페이지네이션으로 조회할 수 있다.', async () => {
+      /**
+       * 새로운 상품에 대한 새로운 필수 옵션을 10개를 생성하고, 페이지네이션으로 5개씩 조회하는 상황을 테스트 합니다.
+       */
+
+      const { data: product } = await controller.createProduct(testId, testProduct);
+
+      await Promise.all(
+        new Array(10).fill(0).map(() => {
+          return controller.createProductOptions(
+            testId,
+            product.id,
+            { isRequire: true },
+            { name: v4().slice(0, 10), isSale: true, price: 1000 },
+          );
+        }),
+      );
+
+      const { data, meta } = await controller.getProductOptions(testId, product.id, { isRequire: true }, { limit: 5 });
+
+      const isTrueProduct = data.every((d) => d.productId === product.id);
+      expect(isTrueProduct).toBe(true);
+
+      expect(data.length).toBe(5);
+      expect(meta.take).toBe(5);
+      expect(meta.page).toBe(2);
+    });
+
+    it.todo('seller는 판매중이 아닌(isSale = false) 상품 필수 옵션도 조회할 수 있다.');
+
+    it.todo('seller는 특정 가격의 상품 필수 옵션을 조회할 수 있다.');
+
+    it.todo('seller는 가격 오름차순으로 상품 필수 옵션을 조회할 수 있다.');
+
+    it.todo('seller는 가격 내림차순으로 상품 필수 옵션을 조회할 수 있다.');
+
+    it.todo('seller는 해당 키워드를 가진 상품 필수 옵션을 조회할 수 있다.');
+  });
+
+  describe('seller는 등록된 선택 상품의 정보를 조회할 수 있다.', () => {
+    it.todo('seller는 등록된 상품 선택 옵션을 조회할 수 있다.');
   });
 
   describe('seller는 등록된 상품의 정보를 수정할 수 있다.', () => {

--- a/src/types/order-by.type.ts
+++ b/src/types/order-by.type.ts
@@ -1,0 +1,1 @@
+export type order = 'asc' | 'desc';


### PR DESCRIPTION
# Overview
Seller API에 상품 필수/선택 옵션 조회 API를 추가합니다.

Get요청으로 seller는 자신이 등록한 상품에 대한 필수 옵션 및 선택 옵션을 페이지네이션으로 조회할 수 있습니다.

## Implementations(보충설명)
API는 아래 조건을 만족합니다.

- 판매중이 아닌 `(isSale = false)` 상품 필수/선택 옵션도 조회할 수 있다.
- 특정 가격의 상품 필수/선택 옵션을 조회할 수 있다.
- 가격 오름차순/내림차순으로 상품 필수/선택 옵션을 조회할 수 있다.
- 해당 키워드를 가진 상품 필수/선택 옵션을 조회할 수 있다.