### PR TITLE
e2e 테스트 도입

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,19 +112,20 @@ Git 이용한 첫 프로젝트입니다. 기초적인 clone, pull, push부터 ch
 **학습 기록**
 
 - [github commit convension #7](https://github.com/rimo030/nestjs-e-commerce-frame/issues/7#issue-1973493348)
+- ✏️[[Git] Git 브랜치 전략](https://munak.tistory.com/196)
 
 <br>
 
 ### 📍Node.js / JS
 
-Node.js 백엔드 개발 생태계와 학습했습니다. <br>
-근간이 되는 자바스크립트를 더 잘 이해하고자 노력하였습니다. 블로그에 관련 도서나 자료를 읽고 정리하고 있습니다.
+Node.js 개발 생태계에 대해 배웠습니다. <br>
+근간이 되는 자바스크립트를 더 잘 이해하고자 블로그에 관련 도서나 자료를 읽고 정리하고 있습니다.
 
 **학습 기록**
 
-- ✏️[[JS]JavaScript와 Node.js](https://munak.tistory.com/147)
+- ✏️[[JS] JavaScript와 Node.js](https://munak.tistory.com/147)
 - ✏️[[Node.js] npm과 package.json](https://munak.tistory.com/144)
-- ✏️[[JS] 함수형 프로그래밍(FP : Functional Programming)](https://munak.tistory.com/150)
+- ✏️[[JS] 함수형 프로그래밍 (FP : Functional Programming)](https://munak.tistory.com/150)
 - ✏️[[JS] 자바스크립트가 데이터를 할당하는 방법 (feat. 불변성, 가변성)](https://munak.tistory.com/181)
 - ✏️[[JS] 자바스크립트의 변수 복사 (feat. 얕은복사, 깊은복사)](https://munak.tistory.com/183)
 - ✏️[[JS] 프로토타입(Prototype) 이해하기](https://munak.tistory.com/188)
@@ -140,13 +141,15 @@ NestJS를 이용한 첫 프로젝트입니다. DI와 계층 간 역할 분리의
 - [NestJS 구조정리](https://github.com/rimo030/nestjs-e-commerce-frame/issues/6)
 - ✏️[[NestJS] Swagger 적용하기 (feat. API 문서화)](https://munak.tistory.com/186)
 - ✏️[[NestJS] Exception filters 추가하기 (feat.Custom Exception)](https://munak.tistory.com/189)
+- ✏️[[NestJS] Logging Interceptor 추가하기](https://munak.tistory.com/192)
 
 <br>
 
 ### 📍TS
 
-NestJS를 보다 잘 다루기 위해 타입스크립트를 심도 있게 공부하고자 노력하였습니다. <br>
-타입챌린지([rimo030/type-challenges](https://github.com/rimo030/type-challenges))에 도전해 100문제 이상 풀이했습니다!
+타입스크립트를 심도 있게 공부하고자 노력합니다. <br>
+타입챌린지([rimo030/type-challenges](https://github.com/rimo030/type-challenges))에 꾸준히 도전하여 100문제 이상 풀이했습니다. <br>
+관련 내용은 이슈와 블로그로 정리하고 있습니다!
 
 **학습 기록**
 
@@ -163,9 +166,27 @@ NestJS를 보다 잘 다루기 위해 타입스크립트를 심도 있게 공부
 
 <br>
 
+### 📍DB
+
+트랜잭션, 인덱스 등 데이터베이스의 이론적인 내용을 공부했습니다.
+
+- ✏️[[DB] ORM(Object Relational Mapping)이란, 객체-관계 불일치](https://munak.tistory.com/38)
+- ✏️[[DB] 트랜잭션(Transaction)과 트랜잭션 격리 수준(Isolation Level)](https://munak.tistory.com/149)
+- ✏️[[DB] NoSQL과 레디스(Redis)](https://munak.tistory.com/154)
+- ✏️[[DB] SQL의 기본 문법](https://munak.tistory.com/168)
+- ✏️[[DB] 인덱스(Index)](https://munak.tistory.com/175)
+- ✏️[[DB] 정규형(Normal form)](https://munak.tistory.com/176)
+- ✏️[[DB] 락(Lock)과 트랜잭션](https://munak.tistory.com/178)
+- ✏️[[DB] MySQL의 락 (feat. Auto Increment Lock)](https://munak.tistory.com/180)
+- ✏️[[DB] 인덱스에서 B+Tree를 사용하는 이유](https://munak.tistory.com/182)
+- ✏️[[DB] MySQL에서 UUID PK를 사용할 때 고려해야 할 점](https://munak.tistory.com/204)
+
+<br>
+
 ### 📍TDD
 
-TDD의 개념을 배우고 좋은 테스트 코드가 무엇인지 고민해 볼 수 있었습니다.
+TDD의 개념을 배우고 프로젝트에 유닛테스트 및 e2e 테스트를 적용하였습니다.<br>
+좋은 테스트 코드가 무엇일지 고민하며 작성하고 있습니다.
 
 **학습 기록**
 
@@ -181,5 +202,6 @@ NestJS의 주요 ORM인 TypeORM과 Prisma를 모두 사용해 보면서, 기술 
 
 - [TypeORM의 Repository Pattern과 QueryBuilder Pattern #41](https://github.com/rimo030/nestjs-e-commerce-frame/issues/41#issue-1992859474)
 - [Prisma (Migrate from TypeORM) #95](https://github.com/rimo030/nestjs-e-commerce-frame/issues/95#issue-2261681794)
+- [Prisma Soft-delete Client-extensions #108](https://github.com/rimo030/nestjs-e-commerce-frame/issues/108)
 
 <br>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/swagger": "^7.1.16",
         "@prisma/client": "^5.13.0",
         "@types/passport-jwt": "^3.0.13",
+        "axios": "^1.7.2",
         "bcryptjs": "^2.4.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
@@ -3056,8 +3057,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -3069,6 +3069,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3729,7 +3739,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4191,7 +4200,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5167,6 +5175,25 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -5224,7 +5251,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8359,6 +8385,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
-    "test:watch": "jest --watch --detectOpenHandles --testPathPattern=NO_NAME",
+    "test:watch": "jest --clearCache && jest --watch --detectOpenHandles --testPathPattern=NO_NAME",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
@@ -29,6 +29,7 @@
     "@nestjs/swagger": "^7.1.16",
     "@prisma/client": "^5.13.0",
     "@types/passport-jwt": "^3.0.13",
+    "axios": "^1.7.2",
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -15,9 +15,10 @@ export class AuthController {
   @HttpCode(201)
   @Post('/signup')
   @ApiOperation({ summary: 'buyer 생성 API', description: 'buyer를 생성한다.' })
-  async buyerSignUp(@Body() createUserDto: CreateBuyerDto): Promise<{ data: { id: number } }> {
-    const id = await this.authService.buyerSignUp(createUserDto);
-    return { data: id };
+  async buyerSignUp(@Body() createUserDto: CreateBuyerDto): Promise<{ data: { id: number; accessToken: string } }> {
+    const { id } = await this.authService.buyerSignUp(createUserDto);
+    const { accessToken } = await this.authService.buyerLogin(id);
+    return { data: { id, accessToken } };
   }
 
   @UseGuards(BuyerLocalAuthGuard)
@@ -35,9 +36,10 @@ export class AuthController {
   @HttpCode(201)
   @Post('/signup-seller')
   @ApiOperation({ summary: 'seller 생성 API', description: 'seller 생성한다.' })
-  async sellerSignUp(@Body() createSellerDto: CreateSellerDto): Promise<{ data: { id: number } }> {
-    const id = await this.authService.sellerSignUp(createSellerDto);
-    return { data: id };
+  async sellerSignUp(@Body() createSellerDto: CreateSellerDto): Promise<{ data: { id: number; accessToken: string } }> {
+    const { id } = await this.authService.sellerSignUp(createSellerDto);
+    const { accessToken } = await this.authService.sellerLogin(id);
+    return { data: { id, accessToken } };
   }
 
   @UseGuards(SellerLocalAuthGuard)

--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -5,6 +5,7 @@ import { Test } from '@nestjs/testing';
 import { AppModule } from 'src/app.module';
 import { CreateBuyerDto } from 'src/dtos/create-buyer.dto';
 import { CreateSellerDto } from 'src/dtos/create-seller.dto';
+import { test_seller_sign_up } from 'src/test/features/auth/test_seller_sign_up';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 

--- a/src/controllers/category.controller.ts
+++ b/src/controllers/category.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Post, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { CategoryDto } from 'src/dtos/category.dto';
 import { GetPaginationDto } from 'src/dtos/get-pagination.dto';

--- a/src/test/e2e/auth.spec.ts
+++ b/src/test/e2e/auth.spec.ts
@@ -1,0 +1,32 @@
+import { randomInt } from 'crypto';
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from 'src/app.module';
+import { test_seller_sign_up } from '../features/auth/test_seller_sign_up';
+
+describe('Controller', () => {
+  const PORT = randomInt(20000, 50000);
+  let server: INestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    const app = module.createNestApplication();
+    server = await app.init();
+    await server.listen(PORT);
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  describe('Seller 테스트', () => {
+    it('판매자 회원 가입에 성공해야 한다. (e2e)', async () => {
+      const response = await test_seller_sign_up(PORT);
+
+      expect(response.data.id).toBeDefined();
+    });
+  });
+});

--- a/src/test/e2e/auth.spec.ts
+++ b/src/test/e2e/auth.spec.ts
@@ -1,7 +1,9 @@
 import { randomInt } from 'crypto';
+import { v4 } from 'uuid';
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { AppModule } from 'src/app.module';
+import { test_seller_sign_in } from '../features/auth/test_seller_sign_in';
 import { test_seller_sign_up } from '../features/auth/test_seller_sign_up';
 
 describe('Controller', () => {
@@ -23,10 +25,20 @@ describe('Controller', () => {
   });
 
   describe('Seller 테스트', () => {
-    it('판매자 회원 가입에 성공해야 한다. (e2e)', async () => {
+    it('판매자 회원 가입에 성공해야 한다.', async () => {
       const response = await test_seller_sign_up(PORT);
 
       expect(response.data.id).toBeDefined();
+    });
+
+    it(`판매자 로그인에 성공해야 한다. 회원가입이 실패할 경우, 함께 실패한다.`, async () => {
+      const response = await test_seller_sign_in(PORT, {
+        email: `${v4().slice(0, 100)}@gmail.com`,
+        password: v4().slice(0, 20),
+      });
+
+      expect(response.data.accessToken).toBeDefined();
+      expect(typeof response.data.accessToken === 'string').toBe(true);
     });
   });
 });

--- a/src/test/e2e/seller.spec.ts
+++ b/src/test/e2e/seller.spec.ts
@@ -1,0 +1,31 @@
+import { randomInt } from 'crypto';
+import { v4 } from 'uuid';
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from 'src/app.module';
+import { test_seller_sign_in } from '../features/auth/test_seller_sign_in';
+import { test_seller_sign_up } from '../features/auth/test_seller_sign_up';
+import { test_seller_create_product } from '../features/sellers/test_seller_create_product';
+
+describe('Controller', () => {
+  const PORT = randomInt(20000, 50000);
+  let server: INestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    const app = module.createNestApplication();
+    server = await app.init();
+    await server.listen(PORT);
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  describe('Seller 테스트', () => {
+    it('POST seller/product', async () => {});
+  });
+});

--- a/src/test/features/auth/test_seller_sign_in.ts
+++ b/src/test/features/auth/test_seller_sign_in.ts
@@ -3,6 +3,14 @@ import { AuthController } from 'src/auth/auth.controller';
 import { AuthCredentialsDto } from 'src/dtos/auth-credentials.dto';
 import { test_seller_sign_up } from './test_seller_sign_up';
 
+/**
+ * 판매자의 로그인을 테스트한다.
+ * endpoint는 `POST auth/signin-seller` 이다.
+ *
+ * @param PORT 테스트를 하기 위한 포트 번호
+ * @param option 로그인을 하기 위해 필요한 credentials 정보를 담는다. 여기서는 이메일과 패스워드이다.
+ * @returns
+ */
 export async function test_seller_sign_in(
   PORT: number,
   option: AuthCredentialsDto,

--- a/src/test/features/auth/test_seller_sign_in.ts
+++ b/src/test/features/auth/test_seller_sign_in.ts
@@ -1,5 +1,18 @@
+import axios from 'axios';
 import { AuthController } from 'src/auth/auth.controller';
+import { AuthCredentialsDto } from 'src/dtos/auth-credentials.dto';
+import { test_seller_sign_up } from './test_seller_sign_up';
 
-export async function test_seller_sign_in(): Promise<ReturnType<AuthController['sellerSignIn']>> {
-  return 1 as any;
+export async function test_seller_sign_in(
+  PORT: number,
+  option: AuthCredentialsDto,
+): Promise<ReturnType<AuthController['sellerSignIn']>> {
+  await test_seller_sign_up(PORT, option);
+
+  const response = await axios(`http://localhost:${PORT}/auth/signin-seller`, {
+    method: 'POST',
+    data: option satisfies AuthCredentialsDto,
+  });
+
+  return response.data as Awaited<ReturnType<AuthController['sellerSignIn']>>;
 }

--- a/src/test/features/auth/test_seller_sign_in.ts
+++ b/src/test/features/auth/test_seller_sign_in.ts
@@ -1,0 +1,5 @@
+import { AuthController } from 'src/auth/auth.controller';
+
+export async function test_seller_sign_in(): Promise<ReturnType<AuthController['sellerSignIn']>> {
+  return 1 as any;
+}

--- a/src/test/features/auth/test_seller_sign_up.ts
+++ b/src/test/features/auth/test_seller_sign_up.ts
@@ -1,9 +1,11 @@
+import { v4 } from 'uuid';
 import { AuthController } from 'src/auth/auth.controller';
 import { CreateSellerDto } from 'src/dtos/create-seller.dto';
 
 /**
  * 판매자의 회원 가입을 테스트하는 함수이다.
  * e2e로 작성되었으며, 프론트에서 호출한 것과 동일한 과정을 수행한다.
+ * 어떠한 옵션도 받지 않으며, 판매자에 대한 정보는 전부 랜덤으로 생성된다.
  *
  *  endpoint는 `POST auth/signup-seller` 에 해당한다.
  *
@@ -14,11 +16,11 @@ export async function test_seller_sign_up(): Promise<ReturnType<AuthController['
     headers: {},
     method: 'POST',
     body: JSON.stringify({
-      businessNumber: '',
-      email: '',
-      name: '',
-      password: '',
-      phone: '',
+      email: `${v4().slice(0, 100)}@gmail.com`,
+      password: v4().slice(0, 20),
+      name: v4().slice(0, 10),
+      phone: v4().slice(0, 10),
+      businessNumber: v4().slice(0, 100),
     } satisfies CreateSellerDto),
   });
 

--- a/src/test/features/auth/test_seller_sign_up.ts
+++ b/src/test/features/auth/test_seller_sign_up.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { v4 } from 'uuid';
 import { AuthController } from 'src/auth/auth.controller';
 import { CreateSellerDto } from 'src/dtos/create-seller.dto';
@@ -11,19 +12,18 @@ import { CreateSellerDto } from 'src/dtos/create-seller.dto';
  *
  * @returns 판매자가 회원가입한 후 아이디가 조회된다.
  */
-export async function test_seller_sign_up(): Promise<ReturnType<AuthController['sellerSignUp']>> {
-  const response = await fetch('localhost:3000/auth/signup-seller', {
+export async function test_seller_sign_up(PORT: number): Promise<ReturnType<AuthController['sellerSignUp']>> {
+  const response = await axios(`http://localhost:${PORT}/auth/signup-seller`, {
     headers: {},
     method: 'POST',
-    body: JSON.stringify({
+    data: {
       email: `${v4().slice(0, 100)}@gmail.com`,
       password: v4().slice(0, 20),
       name: v4().slice(0, 10),
       phone: v4().slice(0, 10),
       businessNumber: v4().slice(0, 100),
-    } satisfies CreateSellerDto),
+    } satisfies CreateSellerDto,
   });
 
-  const data: Awaited<ReturnType<AuthController['sellerSignUp']>> = await response.json();
-  return data;
+  return response.data as Awaited<ReturnType<AuthController['sellerSignUp']>>;
 }

--- a/src/test/features/auth/test_seller_sign_up.ts
+++ b/src/test/features/auth/test_seller_sign_up.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { v4 } from 'uuid';
 import { AuthController } from 'src/auth/auth.controller';
+import { AuthCredentialsDto } from 'src/dtos/auth-credentials.dto';
 import { CreateSellerDto } from 'src/dtos/create-seller.dto';
 
 /**
@@ -10,15 +11,21 @@ import { CreateSellerDto } from 'src/dtos/create-seller.dto';
  *
  *  endpoint는 `POST auth/signup-seller` 에 해당한다.
  *
+ * @param PORT 테스트하기 위한 포트를 넣어준다.
+ * @param option 만약, 회원가입 시 이메일과 패스워드를 지정하고자 한다면, 값을 대입한다. 단 리턴 결과로 나오지 않으므로 주의한다.
+ *
  * @returns 판매자가 회원가입한 후 아이디가 조회된다.
  */
-export async function test_seller_sign_up(PORT: number): Promise<ReturnType<AuthController['sellerSignUp']>> {
+export async function test_seller_sign_up(
+  PORT: number,
+  option?: AuthCredentialsDto,
+): Promise<ReturnType<AuthController['sellerSignUp']>> {
   const response = await axios(`http://localhost:${PORT}/auth/signup-seller`, {
     headers: {},
     method: 'POST',
     data: {
-      email: `${v4().slice(0, 100)}@gmail.com`,
-      password: v4().slice(0, 20),
+      email: option?.email ?? `${v4().slice(0, 100)}@gmail.com`,
+      password: option?.password ?? v4().slice(0, 20),
       name: v4().slice(0, 10),
       phone: v4().slice(0, 10),
       businessNumber: v4().slice(0, 100),

--- a/src/test/features/auth/test_seller_sign_up.ts
+++ b/src/test/features/auth/test_seller_sign_up.ts
@@ -1,0 +1,27 @@
+import { AuthController } from 'src/auth/auth.controller';
+import { CreateSellerDto } from 'src/dtos/create-seller.dto';
+
+/**
+ * 판매자의 회원 가입을 테스트하는 함수이다.
+ * e2e로 작성되었으며, 프론트에서 호출한 것과 동일한 과정을 수행한다.
+ *
+ *  endpoint는 `POST auth/signup-seller` 에 해당한다.
+ *
+ * @returns 판매자가 회원가입한 후 아이디가 조회된다.
+ */
+export async function test_seller_sign_up(): Promise<ReturnType<AuthController['sellerSignUp']>> {
+  const response = await fetch('localhost:3000/auth/signup-seller', {
+    headers: {},
+    method: 'POST',
+    body: JSON.stringify({
+      businessNumber: '',
+      email: '',
+      name: '',
+      password: '',
+      phone: '',
+    } satisfies CreateSellerDto),
+  });
+
+  const data: Awaited<ReturnType<AuthController['sellerSignUp']>> = await response.json();
+  return data;
+}

--- a/src/test/features/sellers/test_seller_create_product.ts
+++ b/src/test/features/sellers/test_seller_create_product.ts
@@ -1,0 +1,44 @@
+import { v4 } from 'uuid';
+import { SellerController } from 'src/controllers/seller.controller';
+import { CreateProductDto } from 'src/dtos/create-product.dto';
+
+/**
+ * 판매자가 직접 상품을 생성하는 상황을 가정한다.
+ * 리턴되는 상품은 Mock data로, 아무런 의미도 가지고 있지 않다.
+ * e2e 테스트를 위해 `fetch` 함수로 직접 테스트를 한다.
+ *
+ * @todo 추후 더 세밀한 테스트를 위해 option을 통해 상품을 세밀하게 수정할 수 있도록 한다.
+ *
+ * endpoint는 `POST seller/product` 에 해당한다.
+ *
+ * @param options 상품을 생성하기 위해 필요한 정보들
+ * @returns
+ */
+export async function test_seller_create_product(options: {
+  bundleId: number;
+  categoryId: number;
+  companyId: number;
+}): Promise<ReturnType<SellerController['createProduct']>> {
+  const { bundleId, categoryId, companyId } = options;
+  const response = await fetch('http://localhost/3000', {
+    headers: {
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+    body: JSON.stringify({
+      bundleId: bundleId,
+      categoryId: categoryId,
+      companyId: companyId,
+      isSale: true,
+      name: v4().slice(0, 10),
+      description: v4().slice(0, 10),
+      deliveryType: 'FREE',
+      deliveryFreeOver: null,
+      deliveryCharge: 0,
+      img: v4().slice(0, 10),
+    } satisfies CreateProductDto),
+  });
+
+  const data: Awaited<ReturnType<SellerController['createProduct']>> = await response.json();
+  return data;
+}

--- a/src/test/features/sellers/test_seller_create_product.ts
+++ b/src/test/features/sellers/test_seller_create_product.ts
@@ -1,6 +1,8 @@
 import { v4 } from 'uuid';
 import { SellerController } from 'src/controllers/seller.controller';
 import { CreateProductDto } from 'src/dtos/create-product.dto';
+import { test_seller_sign_in } from '../auth/test_seller_sign_in';
+import { test_seller_sign_up } from '../auth/test_seller_sign_up';
 
 /**
  * 판매자가 직접 상품을 생성하는 상황을 가정한다.
@@ -20,8 +22,12 @@ export async function test_seller_create_product(options: {
   companyId: number;
 }): Promise<ReturnType<SellerController['createProduct']>> {
   const { bundleId, categoryId, companyId } = options;
-  const response = await fetch('http://localhost/3000', {
+  const sellerId = await test_seller_sign_up();
+  const signInResponse = await test_seller_sign_in();
+
+  const response = await fetch('http://localhost/3000/seller/product', {
     headers: {
+      authorization: `bearer ${signInResponse.data.accessToken}`,
       'content-type': 'application/json',
     },
     method: 'POST',

--- a/src/test/features/sellers/test_seller_create_product.ts
+++ b/src/test/features/sellers/test_seller_create_product.ts
@@ -10,24 +10,31 @@ import { test_seller_sign_up } from '../auth/test_seller_sign_up';
  * e2e 테스트를 위해 `fetch` 함수로 직접 테스트를 한다.
  *
  * @todo 추후 더 세밀한 테스트를 위해 option을 통해 상품을 세밀하게 수정할 수 있도록 한다.
+ * @todo category 생성 API가 있어야 한다.
+ * @todo company 생성 API가 있어야 한다.
+ * @todo (optional) product bundle 생성 API가 있어야 한다.
  *
  * endpoint는 `POST seller/product` 에 해당한다.
  *
+ * @param PORT 테스트를 하기 위한 포트 번호
  * @param options 상품을 생성하기 위해 필요한 정보들
  * @returns
  */
-export async function test_seller_create_product(options: {
-  bundleId: number;
-  categoryId: number;
-  companyId: number;
-}): Promise<ReturnType<SellerController['createProduct']>> {
+export async function test_seller_create_product(
+  PORT: number,
+  options: {
+    bundleId: number;
+    categoryId: number;
+    companyId: number;
+  },
+): Promise<ReturnType<SellerController['createProduct']>> {
   const { bundleId, categoryId, companyId } = options;
-  const sellerId = await test_seller_sign_up();
-  const signInResponse = await test_seller_sign_in();
+  const signUpResponse = await test_seller_sign_up(PORT);
+  const accessToken = signUpResponse.data.accessToken;
 
   const response = await fetch('http://localhost/3000/seller/product', {
     headers: {
-      authorization: `bearer ${signInResponse.data.accessToken}`,
+      authorization: `bearer ${accessToken}`,
       'content-type': 'application/json',
     },
     method: 'POST',


### PR DESCRIPTION
## Background(배경지식)
- e2e 테스트 작성 방식을 공유
    - 프론트와 백엔드의 연결을 우선적으로 테스트한 다음 unit으로 갈 수 있도록 e2e를 우선 수행합니다.
    - 작성된 테스트는 다른 테스트를 작성할 때 사용할 수 있도록 함수 단위로 작성합니다.
    - 작성된 테스트는 다른 테스트를 작성할 때 `beforeAll` 구문에 넣어 mock data 생성에 활용할 수도 있습니다.

## Implementations(보충설명)
- `e2e` 테스트에 대한 짧막한 글을 읽어보면 좋겠습니다!
- 폴더 구조 설명
    - `test/e2e` : e2e 테스트가 모입니다.
    - `test/features` : API 단위로 함수가 하나 씩 모입니다. e2e 폴더에서 jest를 이용해 테스트하기도 하고, mock data 생성에 사용도 됩니다.