### PR TITLE
회사 등록 API를 추가했습니다.

### DIFF
--- a/src/controllers/company.controller.ts
+++ b/src/controllers/company.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, Post, Query, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { SellerJwtAuthGuard } from 'src/auth/guards/seller-jwt.guard';
 import { UserId } from 'src/decorators/user-id.decorator';
 import { CompanyDto } from 'src/dtos/company.dto';
+import { CreateCompanyDto } from 'src/dtos/create-company.dto';
 import { GetCompanyPaginationDto } from 'src/dtos/get-company-pagination.dto';
 import { PaginationDto } from 'src/dtos/pagination.dto';
 import { CompanyService } from 'src/services/company.service';
@@ -14,6 +15,19 @@ import { createPaginationResponseDto } from 'src/util/functions/pagination-util.
 @UseGuards(SellerJwtAuthGuard)
 export class CompanyController {
   constructor(private readonly companyService: CompanyService) {}
+
+  @HttpCode(201)
+  @Post()
+  @ApiOperation({ summary: '회사 등록 API', description: '회사를 등록할 수 있다.' })
+  async createCompany(
+    @UserId() sellerId: number,
+    @Body() createCompanyDto: CreateCompanyDto,
+  ): Promise<{
+    data: CompanyDto;
+  }> {
+    const company = await this.companyService.createCompany(sellerId, createCompanyDto);
+    return { data: company };
+  }
 
   @Get()
   @ApiOperation({ summary: '회사 조회 API', description: '등록된 회사를 페이지네이션으로 확인할 수 있다.' })

--- a/src/controllers/company.controller.ts
+++ b/src/controllers/company.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, HttpCode, Post, Query, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { SellerJwtAuthGuard } from 'src/auth/guards/seller-jwt.guard';
 import { UserId } from 'src/decorators/user-id.decorator';
 import { CompanyDto } from 'src/dtos/company.dto';
@@ -15,6 +15,20 @@ import { createPaginationResponseDto } from 'src/util/functions/pagination-util.
 @UseGuards(SellerJwtAuthGuard)
 export class CompanyController {
   constructor(private readonly companyService: CompanyService) {}
+
+  @HttpCode(201)
+  @Post('bulk')
+  @ApiBody({ type: [CreateCompanyDto] })
+  @ApiOperation({ summary: '회사 다수 등록 API', description: '회사를 여러개 등록할 수 있다.' })
+  async createCompanies(
+    @UserId() sellerId: number,
+    @Body() createCompanyDtos: CreateCompanyDto[],
+  ): Promise<{
+    data: CompanyDto[];
+  }> {
+    const companies = await this.companyService.createCompanies(sellerId, createCompanyDtos);
+    return { data: companies };
+  }
 
   @HttpCode(201)
   @Post()

--- a/src/dtos/create-company.dto.ts
+++ b/src/dtos/create-company.dto.ts
@@ -1,0 +1,9 @@
+import { Company } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmptyString } from 'src/decorators/is-not-empty-string.decorator';
+
+export class CreateCompanyDto implements Pick<Company, 'name'> {
+  @ApiProperty({ type: String, description: '이름', required: true, example: 'mycompany' })
+  @IsNotEmptyString(1, 128)
+  name!: string;
+}

--- a/src/services/company.service.ts
+++ b/src/services/company.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { CompanyDto } from 'src/dtos/company.dto';
+import { CreateCompanyDto } from 'src/dtos/create-company.dto';
 import { GetCompanyPaginationDto } from 'src/dtos/get-company-pagination.dto';
 import { SellerNotFoundException } from 'src/exceptions/auth.exception';
 import { PaginationResponse } from 'src/interfaces/pagination-response.interface';
@@ -15,7 +16,7 @@ export class CompanyService {
    * @param sellerId 판매자 아이디가 존재해야 회사를 생성할 수 있습니다.
    * @param createCompanyDto 생성할 회사의 정보입니다.
    */
-  async createCompany(sellerId: number, createCompanyDto: { name: string }): Promise<{ id: number; name: string }> {
+  async createCompany(sellerId: number, createCompanyDto: CreateCompanyDto): Promise<CompanyDto> {
     const seller = await this.prisma.seller.findUnique({
       select: { id: true },
       where: { id: sellerId },
@@ -37,10 +38,7 @@ export class CompanyService {
    * @param sellerId 판매자 아이디가 존재해야 회사를 생성할 수 있습니다.
    * @param createCompanyDtos 생성할 회사들의 정보 입니다.
    */
-  async createCompanies(
-    sellerId: number,
-    createCompanyDtos: { name: string }[],
-  ): Promise<{ id: number; name: string }[]> {
+  async createCompanies(sellerId: number, createCompanyDtos: CreateCompanyDto[]): Promise<CompanyDto[]> {
     const seller = await this.prisma.seller.findUnique({
       select: { id: true },
       where: { id: sellerId },

--- a/src/test/e2e/company.spec.ts
+++ b/src/test/e2e/company.spec.ts
@@ -1,0 +1,43 @@
+import { randomInt } from 'crypto';
+import { v4 } from 'uuid';
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from 'src/app.module';
+import { test_seller_sign_up } from '../features/auth/test_seller_sign_up';
+import { test_create_company } from '../features/companies/test_company_create_company';
+
+describe('Controller', () => {
+  const PORT = randomInt(20000, 50000);
+  let server: INestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    const app = module.createNestApplication();
+    server = await app.init();
+    await server.listen(PORT);
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  describe('Company 테스트', () => {
+    it('회사 등록에 성공해야 한다.', async () => {
+      const response = await test_create_company(PORT);
+
+      expect(response.data.id).toBeDefined();
+    });
+
+    it('판매자 계정으로 회사 등록에 성공해야 한다.', async () => {
+      const { data: seller } = await test_seller_sign_up(PORT);
+      const testname = v4();
+      const response = await test_create_company(PORT, seller.accessToken, { name: testname });
+
+      expect(response.data.id).toBeDefined();
+      expect(response.data.name).toBe(testname);
+    });
+  });
+});

--- a/src/test/e2e/company.spec.ts
+++ b/src/test/e2e/company.spec.ts
@@ -4,6 +4,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { AppModule } from 'src/app.module';
 import { test_seller_sign_up } from '../features/auth/test_seller_sign_up';
+import { test_create_companies } from '../features/companies/test_company_create_companies';
 import { test_create_company } from '../features/companies/test_company_create_company';
 
 describe('Controller', () => {
@@ -38,6 +39,12 @@ describe('Controller', () => {
 
       expect(response.data.id).toBeDefined();
       expect(response.data.name).toBe(testname);
+    });
+
+    it('회사 다수 등록에 성공해야 한다.', async () => {
+      const response = await test_create_companies(PORT);
+
+      expect(response.data.every(Boolean)).toBeDefined();
     });
   });
 });

--- a/src/test/features/companies/test_company_create_companies.ts
+++ b/src/test/features/companies/test_company_create_companies.ts
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import { v4 } from 'uuid';
+import { CompanyController } from 'src/controllers/company.controller';
+import { CreateCompanyDto } from 'src/dtos/create-company.dto';
+import { test_seller_sign_up } from '../auth/test_seller_sign_up';
+
+/**
+ * 회사 다수 생성을 테스트 합니다.
+ * 엔드포인트는 `POST company/bulk` 입니다.
+ *
+ * @param PORT 테스트를 하기 위한 포트 번호 입니다.
+ * @param accessToken 인증에 사용할 판매자 토큰입니다. 주어지지 않을 경우 임의의 seller가 생성됩니다.
+ * @param options 저장할 회사의 데이터 객체 배열 입니다. 주어지지 않을 경우 랜덤한 이름을 가진 임의의 회사를 10개 생성합니다.
+ */
+export async function test_create_companies(
+  PORT: number,
+  accessToken?: string,
+  options?: CreateCompanyDto[],
+): Promise<ReturnType<CompanyController['createCompanies']>> {
+  if (!accessToken) {
+    const signUpResponse = await test_seller_sign_up(PORT);
+    accessToken = signUpResponse.data.accessToken;
+  }
+
+  const response = await axios(`http://localhost:${PORT}/company/bulk`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    data:
+      options?.map((o) => ({ name: o?.name ?? v4() })) ??
+      (Array(10)
+        .fill(0)
+        .map(() => ({ name: v4() })) satisfies CreateCompanyDto[]),
+  });
+
+  return response.data as Awaited<ReturnType<CompanyController['createCompanies']>>;
+}

--- a/src/test/features/companies/test_company_create_company.ts
+++ b/src/test/features/companies/test_company_create_company.ts
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import { v4 } from 'uuid';
+import { CompanyController } from 'src/controllers/company.controller';
+import { CreateCategoryDto } from 'src/dtos/create-category.dto';
+import { CreateCompanyDto } from 'src/dtos/create-company.dto';
+import { test_seller_sign_up } from '../auth/test_seller_sign_up';
+
+/**
+ * 회사 생성을 테스트 합니다.
+ * 엔드포인트는 `POST company` 입니다.
+ *
+ * @param PORT 테스트를 하기 위한 포트 번호 입니다.
+ * @param accessToken 인증에 사용할 판매자 토큰입니다.
+ * @param option 저장할 회사의 데이터 입니다.
+ */
+export async function test_create_company(
+  PORT: number,
+  accessToken?: string,
+  option?: CreateCompanyDto,
+): Promise<ReturnType<CompanyController['createCompany']>> {
+  if (!accessToken) {
+    const signUpResponse = await test_seller_sign_up(PORT);
+    accessToken = signUpResponse.data.accessToken;
+  }
+
+  const response = await axios(`http://localhost:${PORT}/company`, {
+    method: 'POST',
+    data: { name: option?.name ?? v4() } satisfies CreateCategoryDto,
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  return response.data as Awaited<ReturnType<CompanyController['createCompany']>>;
+}


### PR DESCRIPTION
# Overview
Company API에 회사 등록 / 다수 등록 API를 추가했습니다.

## Implementations
아래 요청을 처리합니다. 

- POST company
- POST company/bulk

## To Reviewers
회사(company)와 판매자(seller) 간 관계 설정에 대해 질문이 있습니다.

현재 company 조회 및 등록 시 seller 인증을 사용하지만, 관계는 설정되지 않은 상태입니다.
프리즈마 모델은 다음과 같습니다.

```prisma
model Company {
  id          Int       @id @default(autoincrement())
  createdAt   DateTime  @default(now()) @db.DateTime(6) @map("created_at")
  updatedAt   DateTime  @default(now()) @db.DateTime(6) @map("updated_at")
  deletedAt   DateTime? @db.DateTime(6) @map("deleted_at")
  name        String    @db.VarChar(128)
  products    Product[]

  @@map("company")
}
```


```prisma
model Seller {
  id                Int              @id @default(autoincrement())
  createdAt         DateTime         @default(now()) @db.DateTime(6) @map("created_at")
  updatedAt         DateTime         @default(now()) @db.DateTime(6) @map("updated_at")
  deletedAt         DateTime?        @db.DateTime(6) @map("deleted_at")
  email             String           @unique() @db.VarChar(128)
  password          String           @db.VarChar(512)
  name              String           @db.VarChar(32)
  phone             String           @db.VarChar(11)
  businessNumber    String           @db.VarChar(128) @map("business_number")
  products          Product[]
  productBundles    ProductBundle[]
  
  @@map("seller")
} 
```

아래의 company 등록 과제를 고려했을 때, 다음과 같이 변경이 이루어져야 한다고 생각했습니다.
멘토님은 어떻게 생각하시나요?

1. 둘의 관계를 다대다로 설정 (연결테이블로 관리)
2. 사업자번호를 회사 테이블로 옮겨 저장
3. 회사의 정보를 저장하기 위한 칼럼 추가 (업태, 종목, 홈페이지 주소 등)



```ts
it.todo('판매자는 누구나 회사를 등록할 수 있어야 한다.');

    /**
     * 회사는 모두 유니크해야 하며, 회사의 동일 여부는 회사의 사업자 번호를 기준으로 해야 한다.
     * 사업자 번호에 대한 칼럼을 추가하고, 해당 칼럼을 비교하여 이미 존재할 경우 업데이트를 헤야 한다.
     * 단, 업데이트할 때에는 이전에 정보가 추가되었을 가능성을 고려하기 때문이다.
     *
     * 예컨대, 이전 정보에서는 회사의 대표 전화번호가 없었지만, 다른 판매자가 대표 전화번호를 알고 저장할 수도 있기 때문.
     */
    it.todo('기존에 이미 있는 회사일 경우에는 새로 등록되지 않아야 한다.');

    /**
     * 해당 정보는 입력을 받아 조회하는 게 아니라, 미리 국세청 등 공공 API를 통해 저장해야 한다.
     * 저장 시점은 POST로 회사를 저장할 때 일어나야 한다.
     * 아래 테스트 코드 외에도 공공 API를 통해 미리 알아낼 수 있는 정보는 다 저장하는 것이 좋다.
     *
     * 회사의 종목이 달라지는 등의 일은 일단 고려하지 않는다.
     * 빈번하게 업데이트가 일어날 수 있는 항목이 아니기 때문에, 판매자의 저장 시점마다 고려한다.
     */
    it.todo('회사는 저장 시 공공 API를 이용해 업종, 업태, 종목 등의 정보를 저장해야 한다.');
```


