### PR TITLE
[Auth] Buyer OAuth 로그인 구조을 확장하였습니다. 

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,12 +27,14 @@ model Buyer {
   createdAt   DateTime    @default(now()) @db.DateTime(6) @map("created_at")
   updatedAt   DateTime    @default(now()) @db.DateTime(6) @map("updated_at")
   deletedAt   DateTime?   @db.DateTime(6) @map("deleted_at")
-  email       String      @unique() @db.VarChar(128)
-  password    String?     @db.VarChar(512)
+  email       String?     @unique() @db.VarChar(128)
+  password    String?     @db.VarChar(512) 
   name        String      @db.VarChar(128)
   gender      Int?        @db.TinyInt
   age         Int?
   phone       String?     @db.VarChar(11)
+  oauthProvider String?   @db.VarChar(50) 
+  oauthId     String?     @db.VarChar(255) 
   boards      Board[]
   carts       Cart[]
   orders      Order[]

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,11 +1,11 @@
 import { Body, Controller, HttpCode, Post, UseGuards, Request, Get } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { UserId } from 'src/decorators/user-id.decorator';
+import { CreateBuyerRequestDto } from 'src/dtos/create-buyer.request.dto';
 import { BuyerLoginResponse } from 'src/interfaces/buyer-login.response.interface';
 import { CommonResponse } from 'src/interfaces/common-response.interface';
 import { SellerLoginResponse } from 'src/interfaces/seller-login.response.interface';
 import { AuthCredentialsRequestDto } from '../dtos/auth-credentials.request.dto';
-import { CreateBuyerRequestDto } from '../dtos/create-buyer.dto';
 import { CreateSellerRequestDto } from '../dtos/create-seller.dto';
 import { AuthService } from './auth.service';
 import { BuyerGoogleOAuthGuard } from './guards/buyer-google-oauth.guard';

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,11 +1,11 @@
 import { Body, Controller, HttpCode, Post, UseGuards, Request, Get } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { UserId } from 'src/decorators/user-id.decorator';
-import { CreateBuyerRequestDto } from 'src/dtos/create-buyer.request.dto';
 import { BuyerLoginResponse } from 'src/interfaces/buyer-login.response.interface';
 import { CommonResponse } from 'src/interfaces/common-response.interface';
 import { SellerLoginResponse } from 'src/interfaces/seller-login.response.interface';
 import { AuthCredentialsRequestDto } from '../dtos/auth-credentials.request.dto';
+import { CreateBuyerRequestDto } from '../dtos/create-buyer.request.dto';
 import { CreateSellerRequestDto } from '../dtos/create-seller.dto';
 import { AuthService } from './auth.service';
 import { BuyerGoogleOAuthGuard } from './guards/buyer-google-oauth.guard';
@@ -46,6 +46,19 @@ export class AuthController {
     return { data };
   }
 
+  @UseGuards(BuyerGoogleOAuthGuard)
+  @Get('google')
+  @ApiOperation({ summary: 'buyer google 로그인 API', description: 'buyer google oauth 기능' })
+  async googleAuth() {}
+
+  @UseGuards(BuyerGoogleOAuthGuard)
+  @Get('google/callback')
+  @ApiOperation({ summary: 'buyer google oauth 콜백 API', description: 'buyer google oauth 토큰 발급 기능' })
+  async googleAuthRedirect(@Request() req): Promise<CommonResponse<BuyerLoginResponse>> {
+    const data = await this.authService.buyerGoogleOAuthLogin(req.user);
+    return { data };
+  }
+
   @HttpCode(201)
   @Post('/signup-seller')
   @ApiOperation({ summary: 'seller 생성 API', description: 'seller 회원가입 기능' })
@@ -76,17 +89,6 @@ export class AuthController {
   ): Promise<CommonResponse<SellerLoginResponse>> {
     const data = await this.authService.sellerRefresh(refreshToken);
     return { data };
-  }
-
-  @Get('google')
-  @UseGuards(BuyerGoogleOAuthGuard)
-  async googleAuth() {}
-
-  @Get('google/callback')
-  @UseGuards(BuyerGoogleOAuthGuard)
-  async googleAuthRedirect(@Request() req) {
-    const accessToken = await this.authService.buyerGoogleOAuthLogin(req.user);
-    return { data: accessToken };
   }
 
   @Get('kakao')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -2,16 +2,20 @@ import bcrypt from 'bcryptjs';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
+import { BuyerGoogleCredentialsRequest } from 'src/interfaces/buyer-google-login.request.interface';
 import { BuyerLoginResponse } from 'src/interfaces/buyer-login.response.interface';
 import { SellerLoginResponse } from 'src/interfaces/seller-login.response.interface';
 import { PrismaService } from 'src/services/prisma.service';
+import { oauthProviderType } from 'src/types/oauth.provider.type';
+import { Partial } from 'src/types/partial-type';
 import { AuthCredentialsRequestDto } from '../dtos/auth-credentials.request.dto';
-import { CreateBuyerRequestDto } from '../dtos/create-buyer.dto';
+import { CreateBuyerRequestDto } from '../dtos/create-buyer.request.dto';
 import { CreateSellerRequestDto } from '../dtos/create-seller.dto';
 import {
   AuthForbiddenException,
   BuyerRefreshUnauthrizedException,
   BuyerUnauthrizedException,
+  OAuthNotFoundException,
   SellerEmailNotFoundException,
   SellerNotFoundException,
   SellerUnauthrizedException,
@@ -86,31 +90,15 @@ export class AuthService {
    * buyer의 구글 로그인을 처리합니다.
    * 등록되지 않은 이메일일 경우 새로 buyer를 생성합니다. 등록된 경우 jwt 토큰을 발행합니다.
    *
-   * @param BuyerGoogleCredentialsDto BuyerGoogleStrategy에서 전달된 정보입니다.
+   * @param buyerGoogleCredentialsReuqest BuyerGoogleStrategy에서 전달된 정보입니다.
    */
-  async buyerGoogleOAuthLogin(BuyerGoogleCredentialsDto: {
-    email?: string;
-    name?: string;
-    accessToken: string;
-  }): Promise<{ accessToken: string }> {
-    const { email, name } = BuyerGoogleCredentialsDto;
-
-    if (email && name) {
-      const buyer = await this.prisma.buyer.findUnique({ select: { id: true }, where: { email } });
-
-      if (!buyer) {
-        const buyerId = await this.prisma.buyer.create({
-          select: { id: true },
-          data: { email, name },
-        });
-        const accessToken = this.jwtService.sign(buyerId, {
-          secret: this.configService.get('JWT_SECRET_BUYER'),
-        });
-        return { accessToken };
-      }
-      return this.buyerLogin(buyer.id);
+  async buyerGoogleOAuthLogin(
+    buyerGoogleCredentialsReuqest: BuyerGoogleCredentialsRequest,
+  ): Promise<BuyerLoginResponse> {
+    if (!buyerGoogleCredentialsReuqest.id) {
+      throw new OAuthNotFoundException();
     }
-    throw new AuthForbiddenException();
+    return await this.handleGoogleOAuthBuyerLogin(buyerGoogleCredentialsReuqest);
   }
 
   /**
@@ -173,7 +161,7 @@ export class AuthService {
    */
   async sellerRefresh(refreshToken: string): Promise<BuyerLoginResponse> {
     const { id } = await this.verifySellerRefreshToken(refreshToken);
-    return await this.sellerLogin(id);
+    return await this.buyerLogin(id);
   }
 
   /**
@@ -341,5 +329,48 @@ export class AuthService {
     } catch (error) {
       throw new SellerEmailNotFoundException();
     }
+  }
+
+  private async handleGoogleOAuthBuyerLogin(buyerGoogleCredentialsReuqest: BuyerGoogleCredentialsRequest) {
+    const { id, accessToken, email, name } = buyerGoogleCredentialsReuqest;
+
+    const buyer = await this.findOAuthBuyer(id, 'GOOGLE');
+    if (!buyer) {
+      return await this.createOAuthBuyerAndLogin({ email, name }, id, 'GOOGLE');
+    }
+    return await this.buyerLogin(buyer.id);
+  }
+
+  private async findOAuthBuyer(oauthId: string, oauthProvider: oauthProviderType): Promise<{ id: number } | null> {
+    return await this.prisma.buyer.findFirst({
+      select: { id: true },
+      where: { oauthId, oauthProvider },
+    });
+  }
+
+  private async createOAuthBuyerAndLogin(
+    createBuyerRequestDto: Partial<CreateBuyerRequestDto>,
+    oauthId: string,
+    oauthProvider: oauthProviderType,
+  ): Promise<BuyerLoginResponse> {
+    const { email, password, name, gender, age, phone } = createBuyerRequestDto;
+
+    const fallbackName = `${oauthId}_${oauthProvider}`;
+
+    const { id } = await this.prisma.buyer.create({
+      select: { id: true },
+      data: {
+        email: email ?? null,
+        password: password ?? null,
+        name: name ?? fallbackName,
+        gender: gender ?? null,
+        age: age ?? null,
+        phone: phone ?? null,
+        oauthId,
+        oauthProvider,
+      },
+    });
+
+    return await this.buyerLogin(id);
   }
 }

--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -3,9 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Test } from '@nestjs/testing';
 import { AppModule } from 'src/app.module';
-import { CreateBuyerRequestDto } from 'src/dtos/create-buyer.dto';
+import { CreateBuyerRequestDto } from 'src/dtos/create-buyer.request.dto';
 import { CreateSellerRequestDto } from 'src/dtos/create-seller.dto';
-import { test_seller_sign_up } from 'src/test/features/auth/test_seller_sign_up';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 

--- a/src/auth/strategies/buyer-google-oauth.strategy.ts
+++ b/src/auth/strategies/buyer-google-oauth.strategy.ts
@@ -2,6 +2,7 @@ import { Profile, Strategy } from 'passport-google-oauth20';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
+import { BuyerGoogleCredentialsRequest } from 'src/interfaces/buyer-google-login.request.interface';
 
 @Injectable()
 export class BuyerGoogleStrategy extends PassportStrategy(Strategy, 'buyer-google') {
@@ -14,20 +15,13 @@ export class BuyerGoogleStrategy extends PassportStrategy(Strategy, 'buyer-googl
     });
   }
 
-  async validate(
-    accessToken: string,
-    refreshToken: string,
-    profile: Profile,
-  ): Promise<{
-    email: string | undefined;
-    name: string | undefined;
-    accessToken: string;
-  }> {
-    const { emails, name } = profile;
+  async validate(accessToken: string, refreshToken: string, profile: Profile): Promise<BuyerGoogleCredentialsRequest> {
+    const { id, emails, name } = profile;
     return {
+      id,
+      accessToken,
       email: emails ? emails[0].value : emails,
       name: name?.givenName,
-      accessToken,
     };
   }
 }

--- a/src/dtos/create-buyer.request.dto.ts
+++ b/src/dtos/create-buyer.request.dto.ts
@@ -8,7 +8,7 @@ import { AuthCredentialsRequestDto } from './auth-credentials.request.dto';
 
 export class CreateBuyerRequestDto
   extends AuthCredentialsRequestDto
-  implements Pick<Buyer, 'name' | 'gender' | 'age' | 'phone'>
+  implements Partial<Pick<Buyer, 'name' | 'gender' | 'age' | 'phone'>>
 {
   @ApiProperty({ type: String, description: '이름', required: true, example: 'myname' })
   @IsNotEmptyString(1, 128)
@@ -16,11 +16,11 @@ export class CreateBuyerRequestDto
 
   @ApiProperty({ type: Number, description: '성별(남자 0, 여자 1)', required: true, example: 1 })
   @IsOptionalNumber('int', { min: 0, max: 1 })
-  gender!: number | null;
+  gender?: number | null;
 
   @ApiProperty({ type: Number, description: '나이', required: true, example: 20 })
   @IsOptionalNumber('int')
-  age!: number | null;
+  age?: number | null;
 
   @ApiProperty({
     type: String,
@@ -30,5 +30,5 @@ export class CreateBuyerRequestDto
   })
   @Transform(({ value }) => value.replace(/-/g, ''))
   @IsOptionalString(11, 11)
-  phone!: string | null;
+  phone?: string | null;
 }

--- a/src/exceptions/auth.exception.ts
+++ b/src/exceptions/auth.exception.ts
@@ -6,6 +6,12 @@ export class AuthForbiddenException extends HttpException {
   }
 }
 
+export class OAuthNotFoundException extends HttpException {
+  constructor() {
+    super(`OAuth resource is not found.`, HttpStatus.NOT_FOUND);
+  }
+}
+
 /**
  * Buyer
  */

--- a/src/interfaces/buyer-google-login.request.interface.ts
+++ b/src/interfaces/buyer-google-login.request.interface.ts
@@ -1,0 +1,6 @@
+export interface BuyerGoogleCredentialsRequest {
+  id: string;
+  accessToken: string;
+  email?: string | null;
+  name?: string | null;
+}

--- a/src/test/e2e/auth.spec.ts
+++ b/src/test/e2e/auth.spec.ts
@@ -1,3 +1,4 @@
+import axios, { AxiosError } from 'axios';
 import { randomInt } from 'crypto';
 import { v4 } from 'uuid';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
@@ -69,6 +70,20 @@ describe('Controller', () => {
       const refreshResponse = await test_buyer_refresh(PORT, refreshToken);
       expect(refreshResponse.data.accessToken).toBeDefined();
       expect(refreshResponse.data.refreshToken).toBeDefined();
+    });
+
+    it(`구매자가 Google oauth 로그인을 시도한 경우 구글 로그인 페이지로 리디렉션이 일어나는지 검증한다.`, async () => {
+      try {
+        await axios.get(`http://localhost:${PORT}/auth/google`, { maxRedirects: 0 });
+      } catch (error) {
+        if (axios.isAxiosError(error)) {
+          const axiosError = error as AxiosError;
+          expect(axiosError.response?.status).toBe(302);
+          expect(axiosError.response?.headers.location?.startsWith('https://accounts.google.com')).toBe(true);
+        } else {
+          throw error;
+        }
+      }
     });
   });
 

--- a/src/test/features/auth/test_buyer_sign_up.ts
+++ b/src/test/features/auth/test_buyer_sign_up.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { v4 } from 'uuid';
 import { AuthController } from 'src/auth/auth.controller';
 import { AuthCredentialsRequestDto } from 'src/dtos/auth-credentials.request.dto';
-import { CreateBuyerRequestDto } from 'src/dtos/create-buyer.dto';
+import { CreateBuyerRequestDto } from 'src/dtos/create-buyer.request.dto';
 
 /**
  * 구매자의 회원 가입을 테스트하는 함수이다.

--- a/src/types/oauth.provider.type.ts
+++ b/src/types/oauth.provider.type.ts
@@ -1,0 +1,1 @@
+export type oauthProviderType = 'GOOGLE' | 'KAKAO';

--- a/src/types/partial-type.ts
+++ b/src/types/partial-type.ts
@@ -1,0 +1,3 @@
+export type Partial<T> = {
+  [key in keyof T]?: T[key] | null;
+};


### PR DESCRIPTION
## Overview
- buyer OAuth 관련 구조 변경을 반영하였습니다.

### Implementations
buyer 테이블 스키마 변경사항
```prisma
model Buyer {
  id          Int         @id @default(autoincrement())
  createdAt   DateTime    @default(now()) @db.DateTime(6) @map("created_at")
  updatedAt   DateTime    @default(now()) @db.DateTime(6) @map("updated_at")
  deletedAt   DateTime?   @db.DateTime(6) @map("deleted_at")
  email       String?     @unique() @db.VarChar(128) // optional로 변경됨
  password    String?     @db.VarChar(512) 
  name        String      @db.VarChar(128)
  gender      Int?        @db.TinyInt
  age         Int?
  phone       String?     @db.VarChar(11)
  oauthProvider String?   @db.VarChar(50)  // oauth관련 칼럼 추가됨
  oauthId     String?     @db.VarChar(255)  // oauth관련 칼럼 추가됨
  boards      Board[]
  carts       Cart[]
  orders      Order[]

  @@map("buyer")
}
``` 

서비스 로직 개선 사항
- 변경된 스키마 구조에 따라 로직 변경 (`oauthId`와 `oauthProvider`를 이용해 사용자를 oauth 조회 및 저장 하도록 합니다.)
- optional 파라미터 관련 타입 수정 및 커스텀 `Partail<T>` 구현
- 구글 로그인 e2e 테스트 코드 작성


잔여 태스크
- [ ] 카카오 oauth 로그인 기능 개선
- [ ] 위 기능 테스트 코드 작성